### PR TITLE
25-screen and main menu

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,12 +5,17 @@ plugins {
 
 group = "org.example"
 version = "1.0-SNAPSHOT"
+val exposedVersion = "0.52.0"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
+    implementation("com.h2database:h2:2.2.224")
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+    implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)
+    implementation("org.jetbrains.exposed", "exposed-jdbc", exposedVersion)
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
     testImplementation("io.kotest:kotest-assertions-core:5.9.1")
     testImplementation("io.kotest:kotest-property:5.9.1")
@@ -21,7 +26,7 @@ tasks.test {
 }
 
 application {
-    mainClass = "MainKt"
+    mainClass = "anttracker.MainKt"
 }
 
 kotlin {

--- a/src/main/kotlin/anttracker/Issue.kt
+++ b/src/main/kotlin/anttracker/Issue.kt
@@ -205,14 +205,6 @@ fun nextPage(
     TODO()
 }
 
-/** ------
-This function prints out a message asking the user how they would like
-to search for an issue.
------ */
-fun menu() {
-    TODO()
-}
-
 /** ---
  * This function collects from the user all the information needed to create an issue
 by prompting them for the description, product, affectedRelease, and priority.

--- a/src/main/kotlin/anttracker/Issues.kt
+++ b/src/main/kotlin/anttracker/Issues.kt
@@ -1,0 +1,14 @@
+package anttracker
+
+/** ------
+This function prints out a message asking the user how they would like
+to search for an issue.
+----- */
+fun mkIssuesMenu(): Screen =
+    screenWithMenu {
+        title("Issues")
+        option("Search by Product") { screenWithMenu { content { t -> t.printLine("There are no products at the moment") } } }
+        content { t -> (1..10).forEach { t.printLine("This is issue number $it") } }
+    }
+
+val issuesMenu = mkIssuesMenu()

--- a/src/main/kotlin/anttracker/Main.kt
+++ b/src/main/kotlin/anttracker/Main.kt
@@ -5,38 +5,39 @@ Rev 1 - 2024/07/01 Original by Micah
 entry-point and main-menu of AntTracker.
  */
 
-import anttracker.contact.menu as contactMenu
-import anttracker.issue.menu as issueMenu
-import anttracker.product.menu as productMenu
-import anttracker.release.menu as releaseMenu
-import anttracker.request.menu as requestMenu
+package anttracker
 
-fun main() {
-    while (true) {
-        val mainMenuText =
-            """
-            == MAIN MENU ==
-            1   View/Edit Issue
-            2   New request
-            3   New release
-            4   New contact
-            5   New product
-            
-            Please select a command. ` to exit program: 
-            """.trimIndent()
-        print(mainMenuText)
+class Terminal {
+    fun printLine() = println()
 
-        when (val selection = readln()) {
-            "`" -> break
-            "1" -> issueMenu()
-            "2" -> requestMenu()
-            "3" -> releaseMenu()
-            "4" -> contactMenu()
-            "5" -> productMenu()
-            else -> {
-                println("Bad input: $selection.")
-            }
+    fun printLine(text: String) {
+        println(text)
+    }
+
+    fun prompt(
+        message: String,
+        choices: List<String>,
+    ): String {
+        println("$message: ${choices.joinToString(", ")} ")
+        val choice = readln()
+        if (choices.contains(choice)) {
+            return choice
         }
+        return prompt(message, choices)
+    }
+
+    fun print(message: String) = kotlin.io.print(message)
+}
+
+fun main(args: Array<String>) {
+    val t = Terminal()
+    var currentScreen: Screen? = mainMenu
+
+    while (currentScreen != null) {
+        t.printLine("Press 0 to exit or * for the main menu")
+        t.printLine()
+
+        currentScreen = currentScreen.run(t)
     }
 }
 

--- a/src/main/kotlin/anttracker/MainMenuScreen.kt
+++ b/src/main/kotlin/anttracker/MainMenuScreen.kt
@@ -1,0 +1,24 @@
+package anttracker
+
+val mainMenu =
+    screenWithMenu {
+        title("Main menu")
+        option("Issues") { issuesMenu }
+        option("Requests") { requestsMenu }
+        option("Products") { productsMenu }
+        option("Contacts") { contactsMenu }
+        content { t -> t.printLine("This is the main menu") }
+    }
+
+private val requestsMenu =
+    screenWithMenu {
+        content { t -> t.printLine("We are in the requests menu") }
+    }
+private val productsMenu =
+    screenWithMenu {
+        content { t -> t.printLine("We are in the products menu") }
+    }
+private val contactsMenu =
+    screenWithMenu {
+        content { t -> t.printLine("We are in the contacts menu") }
+    }

--- a/src/main/kotlin/anttracker/Product.kt
+++ b/src/main/kotlin/anttracker/Product.kt
@@ -9,8 +9,6 @@ the creation or selection of product entities.
 
 package anttracker.product
 
-import anttracker.contact.Name
-
 // ----------------------------------------------------------------------------
 // Class for storing the attributes of a given product.
 // ---
@@ -57,5 +55,5 @@ fun menu() {
  * since the name is longer than 30 characters
 ----------------- */
 fun validateProductName(
-    name: Name, // in
+    name: String, // in
 ): Boolean = true

--- a/src/main/kotlin/anttracker/Screen.kt
+++ b/src/main/kotlin/anttracker/Screen.kt
@@ -60,6 +60,7 @@ open class ScreenWithMenu : Screen {
     private fun displayMenu(t: Terminal): Array<Map.Entry<String, ScreenHandler>> {
         val byIndex = options.entries.toTypedArray()
 
+        t.printLine("== $menuTitle ==")
         byIndex.forEachIndexed { index, entry ->
             val nbr = "${index + 1}".padStart(2, ' ')
             t.print(nbr)

--- a/src/main/kotlin/anttracker/Screen.kt
+++ b/src/main/kotlin/anttracker/Screen.kt
@@ -1,0 +1,75 @@
+package anttracker
+
+interface Screen {
+    fun run(t: Terminal): Screen?
+}
+
+fun screenWithMenu(config: ScreenWithMenu.() -> Unit): Screen {
+    val menu = ScreenWithMenu()
+    config(menu)
+    return menu
+}
+
+typealias ScreenHandler = () -> Screen
+
+typealias DisplayFn = (t: Terminal) -> Any?
+
+open class ScreenWithMenu : Screen {
+    private var menuTitle: String = ""
+    private var options: Map<String, ScreenHandler> = mutableMapOf()
+    private var displayContent: DisplayFn = { }
+
+    fun title(theTitle: String) {
+        this.menuTitle = theTitle
+    }
+
+    fun option(
+        description: String,
+        handler: () -> Screen,
+    ) {
+        this.options += description to handler
+    }
+
+    override fun run(t: Terminal): Screen? {
+        val byIndex = displayMenu(t)
+
+        t.printLine()
+        displayContent(t)
+        t.printLine()
+
+        // Ask the user to enter which menu wants to select
+        // Using `0` or `*` is reserved to exit and go to the main menu
+        val choices = (1..byIndex.size).map(Integer::toString) + "0" + "*"
+        // The user needs to choose from the choices that are 0, *, 1, 2, 3, 4...
+        val response = t.prompt("Please choose an option", choices = choices)
+        t.printLine("You chose: $response")
+
+        if (response == "*") {
+            return mainMenu
+        }
+
+        val index = Integer.parseInt(response)
+
+        if (index == 0) {
+            return null
+        }
+
+        return byIndex[index - 1].value()
+    }
+
+    private fun displayMenu(t: Terminal): Array<Map.Entry<String, ScreenHandler>> {
+        val byIndex = options.entries.toTypedArray()
+
+        byIndex.forEachIndexed { index, entry ->
+            val nbr = "${index + 1}".padStart(2, ' ')
+            t.print(nbr)
+            t.printLine(". ${entry.key}")
+        }
+
+        return byIndex
+    }
+
+    fun content(fn: DisplayFn) {
+        displayContent = fn
+    }
+}


### PR DESCRIPTION
## Summary

Created a base interface `Screen` and `ScreenWithMenu` class to help create easily create a menu with options.

I added a utility function `screenWithMenu` that helps to build an instance of `ScreenWithMenu`.

To abstract the operations in the terminal (printing, prompting, etc.), I added a `Terminal` class.

For example, the main menu looks like this:

```kotlin
    screenWithMenu {
        title("Main menu")
        option("Issues") { issuesMenu }
        option("Requests") { requestsMenu }
        option("Products") { productsMenu }
        option("Contacts") { contactsMenu }
        content { t -> t.printLine("This is the main menu") }
    }
```
and it outputs this:

```bash
== Main menu ==
 1. Issues
 2. Requests
 3. Products
 4. Contacts

This is the main menu

Please choose an option: 1, 2, 3, 4, 0, *
```

## Changes

### Main.kt
* Changed the main loop to use an initial screen and loop until there are no more screens to show
* Added the `Terminal` class

### Screen.kt
* Added the `Screen` interface
* Added the `ScreenWithMenu` class
* Added `screenWithMenu` helper function to build screens

### MainMenuScreen.kt
* Added a simple main menu to illustrate the usage of the menu building function

### Issues.kt
* Added a simple issues menu to illustrate the usage of the menu building function
