### PR TITLE
27-customizable prompt in each menu

### DIFF
--- a/src/main/kotlin/anttracker/Issues.kt
+++ b/src/main/kotlin/anttracker/Issues.kt
@@ -6,9 +6,52 @@ to search for an issue.
 ----- */
 fun mkIssuesMenu(): Screen =
     screenWithMenu {
-        title("Issues")
+        title("VIEW/EDIT ISSUE")
+        option("Description") { screenWithMenu { content { t -> t.printLine("There are no issues at the moment") } } }
         option("Search by Product") { screenWithMenu { content { t -> t.printLine("There are no products at the moment") } } }
-        content { t -> (1..10).forEach { t.printLine("This is issue number $it") } }
+        option("Affected release") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no releases at the moment for any product")
+                }
+            }
+        }
+        option("Anticipated release") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no releases at the moment for any product")
+                }
+            }
+        }
+        option("ID") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no issues at the moment for any product")
+                }
+            }
+        }
+
+        option("Status") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no issues at the moment for any product")
+                }
+            }
+        }
+        option("Priority") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no issues at the moment for any product")
+                }
+            }
+        }
+        option("All Issues") {
+            screenWithMenu {
+                content { t ->
+                    t.printLine("There are no issues at the moment for any product")
+                }
+            }
+        }
         promptMessage("Please select search category. ` to abort:")
     }
 

--- a/src/main/kotlin/anttracker/Issues.kt
+++ b/src/main/kotlin/anttracker/Issues.kt
@@ -9,6 +9,7 @@ fun mkIssuesMenu(): Screen =
         title("Issues")
         option("Search by Product") { screenWithMenu { content { t -> t.printLine("There are no products at the moment") } } }
         content { t -> (1..10).forEach { t.printLine("This is issue number $it") } }
+        promptMessage("Please select search category. ` to abort:")
     }
 
 val issuesMenu = mkIssuesMenu()

--- a/src/main/kotlin/anttracker/Main.kt
+++ b/src/main/kotlin/anttracker/Main.kt
@@ -18,7 +18,7 @@ class Terminal {
         message: String,
         choices: List<String>,
     ): String {
-        println("$message: ${choices.joinToString(", ")} ")
+        printLine(message)
         val choice = readln()
         if (choices.contains(choice)) {
             return choice

--- a/src/main/kotlin/anttracker/MainMenuScreen.kt
+++ b/src/main/kotlin/anttracker/MainMenuScreen.kt
@@ -13,11 +13,11 @@ val mainMenu =
 
 private val requestsMenu =
     screenWithMenu {
-        content { t -> t.printLine("We are in the requests menu") }
+        title("NEW REQUEST")
         promptMessage(
             "<Enter> to display (20) more.\n" +
                 "\n" +
-                "Please select affected product. ` to abort:\n",
+                "Please select affected product. ` to abort:",
         )
     }
 private val productsMenu =

--- a/src/main/kotlin/anttracker/MainMenuScreen.kt
+++ b/src/main/kotlin/anttracker/MainMenuScreen.kt
@@ -8,11 +8,17 @@ val mainMenu =
         option("Products") { productsMenu }
         option("Contacts") { contactsMenu }
         content { t -> t.printLine("This is the main menu") }
+        promptMessage("Please select a command. ` to exit program:")
     }
 
 private val requestsMenu =
     screenWithMenu {
         content { t -> t.printLine("We are in the requests menu") }
+        promptMessage(
+            "<Enter> to display (20) more.\n" +
+                "\n" +
+                "Please select affected product. ` to abort:\n",
+        )
     }
 private val productsMenu =
     screenWithMenu {

--- a/src/main/kotlin/anttracker/MainMenuScreen.kt
+++ b/src/main/kotlin/anttracker/MainMenuScreen.kt
@@ -3,10 +3,10 @@ package anttracker
 val mainMenu =
     screenWithMenu {
         title("Main menu")
-        option("Issues") { issuesMenu }
-        option("Requests") { requestsMenu }
-        option("Products") { productsMenu }
-        option("Contacts") { contactsMenu }
+        option("View/Edit Issues") { issuesMenu }
+        option("New Request") { requestsMenu }
+        option("New Contact") { contactsMenu }
+        option("New Product") { productsMenu }
         content { t -> t.printLine("This is the main menu") }
         promptMessage("Please select a command. ` to exit program:")
     }
@@ -22,6 +22,7 @@ private val requestsMenu =
     }
 private val productsMenu =
     screenWithMenu {
+        promptMessage("Please enter product name (1-30 characters). ` to exit: ")
         content { t -> t.printLine("We are in the products menu") }
     }
 private val contactsMenu =

--- a/src/main/kotlin/anttracker/Screen.kt
+++ b/src/main/kotlin/anttracker/Screen.kt
@@ -44,20 +44,16 @@ open class ScreenWithMenu : Screen {
 
         // Ask the user to enter which menu wants to select
         // Using `0` or `*` is reserved to exit and go to the main menu
-        val choices = (1..byIndex.size).map(Integer::toString) + "0" + "*"
+        val choices = (1..byIndex.size).map(Integer::toString) + "`"
         // The user needs to choose from the choices that are 0, *, 1, 2, 3, 4...
         val response = t.prompt(promptMessage, choices = choices)
         t.printLine("You chose: $response")
 
-        if (response == "*") {
-            return mainMenu
+        if (response == "`") {
+            return null
         }
 
         val index = Integer.parseInt(response)
-
-        if (index == 0) {
-            return null
-        }
 
         return byIndex[index - 1].value()
     }

--- a/src/main/kotlin/anttracker/Screen.kt
+++ b/src/main/kotlin/anttracker/Screen.kt
@@ -47,7 +47,6 @@ open class ScreenWithMenu : Screen {
         val choices = (1..byIndex.size).map(Integer::toString) + "`"
         // The user needs to choose from the choices that are 0, *, 1, 2, 3, 4...
         val response = t.prompt(promptMessage, choices = choices)
-        t.printLine("You chose: $response")
 
         if (response == "`") {
             return null

--- a/src/main/kotlin/anttracker/Screen.kt
+++ b/src/main/kotlin/anttracker/Screen.kt
@@ -18,6 +18,7 @@ open class ScreenWithMenu : Screen {
     private var menuTitle: String = ""
     private var options: Map<String, ScreenHandler> = mutableMapOf()
     private var displayContent: DisplayFn = { }
+    private var promptMessage: String = ""
 
     fun title(theTitle: String) {
         this.menuTitle = theTitle
@@ -28,6 +29,10 @@ open class ScreenWithMenu : Screen {
         handler: () -> Screen,
     ) {
         this.options += description to handler
+    }
+
+    fun promptMessage(message: String) {
+        this.promptMessage = message
     }
 
     override fun run(t: Terminal): Screen? {
@@ -41,7 +46,7 @@ open class ScreenWithMenu : Screen {
         // Using `0` or `*` is reserved to exit and go to the main menu
         val choices = (1..byIndex.size).map(Integer::toString) + "0" + "*"
         // The user needs to choose from the choices that are 0, *, 1, 2, 3, 4...
-        val response = t.prompt("Please choose an option", choices = choices)
+        val response = t.prompt(promptMessage, choices = choices)
         t.printLine("You chose: $response")
 
         if (response == "*") {


### PR DESCRIPTION
## Summary

Each menu now has a customized prompt that can be set in an instance of `ScreenWithMenu`.

closes #27

## Changes

### Screen.kt
* Added a `promptMessage` field to allow a custom prompt to be passed to a menu

### MainMenuScreen.kt
* Added a custom prompt to `mainMenu` and `issuesMenu`

