### PR TITLE
35-show all issues in db

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,14 @@ repositories {
     mavenCentral()
 }
 
+val exposedVersion = "0.52.0"
+
 dependencies {
+    implementation("com.h2database:h2:2.2.224")
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
+    implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)
+    implementation("org.jetbrains.exposed", "exposed-jdbc", exposedVersion)
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
     testImplementation("io.kotest:kotest-assertions-core:5.9.1")
     testImplementation("io.kotest:kotest-property:5.9.1")

--- a/src/main/kotlin/anttracker/Product.kt
+++ b/src/main/kotlin/anttracker/Product.kt
@@ -9,8 +9,6 @@ the creation or selection of product entities.
 
 package anttracker.product
 
-import anttracker.contact.Name
-
 // ----------------------------------------------------------------------------
 // Class for storing the attributes of a given product.
 // ---
@@ -57,5 +55,5 @@ fun menu() {
  * since the name is longer than 30 characters
 ----------------- */
 fun validateProductName(
-    name: Name, // in
+    name: String, // in
 ): Boolean = true

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -8,7 +8,7 @@ The Request module contains all exported classes and functions pertaining to
 package anttracker.request
 
 import anttracker.contact.Name
-import anttracker.issue.Issue
+import anttracker.issues.Issue
 import anttracker.release.ReleaseId
 
 // ----------------------------------------------------------------------------

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -9,12 +9,11 @@ and searching for issues are also present in this file.
 ---------------------------------
  */
 
-package anttracker.issue
+package anttracker.issues
 
 import anttracker.product.Product
 import anttracker.release.ReleaseId
 import anttracker.request.Request
-import java.time.LocalDate
 
 // ------
 
@@ -25,17 +24,6 @@ value class Description(
     init {
         require(description.length in 1..30) {
             "Description length must be between 1 and 30 characters"
-        }
-    }
-}
-
-@JvmInline
-value class Priority(
-    private val priority: Int,
-) {
-    init {
-        require(priority in 1..5) {
-            "Priority of an issue must be between 1 and 5"
         }
     }
 }
@@ -58,12 +46,6 @@ value class IssueId(
         }
     }
 }
-
-data class Issue(
-    val id: IssueId,
-    val information: IssueInformation,
-    val createdAt: LocalDate,
-)
 
 @JvmInline
 value class Days(
@@ -119,7 +101,7 @@ sealed class IssueFilter {
 }
 
 data class PageOf<T>(
-    val page: T,
+    val page: List<T>,
     val offset: Int,
     val limit: Int,
 )

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -1,0 +1,77 @@
+package anttracker.issues
+
+import org.jetbrains.exposed.sql.transactions.transaction
+
+private val noIssuesMatching =
+    screenWithMenu {
+        content { t ->
+            t.printLine("There are no issues matching the criteria")
+        }
+    }
+
+val displayAllIssuesMenu =
+    screenWithMenu {
+        title("Search Results")
+        promptMessage(
+            "<Enter> to display 20 more. \n\n" +
+                "Please select an issue. F to filter. P to print.",
+        )
+        val columns =
+            listOf("ID" to 2, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
+        content { t ->
+            transaction {
+                Issue
+                    .all()
+                    .limit(20)
+                    .map(::toRow)
+                    .let {
+                        t.displayTable(columns, it)
+                    }
+            }
+        }
+    }
+
+private fun toRow(anIssue: Issue): List<Any> {
+    val elements = anIssue.anticipatedRelease.releaseId
+    return listOf(
+        anIssue.id.value,
+        anIssue.description,
+        anIssue.priority,
+        anIssue.status,
+        elements,
+        anIssue.creationDate,
+    )
+}
+
+/** ------
+This function prints out a message asking the user how they would like
+to search for an issue.
+----- */
+fun mkIssuesMenu(): Screen =
+    screenWithMenu {
+        title("VIEW/EDIT ISSUE")
+        promptMessage("Please select search category.")
+        option("Search by description") { screenWithMenu { content { t -> t.printLine("There are no issues at the moment") } } }
+        option("Search by Product") { screenWithMenu { content { t -> t.printLine("There are no products at the moment") } } }
+        option("Search by Affected release") { noIssuesMatching }
+        option("Search by Anticipated release") { noIssuesMatching }
+        option("Search by status") { noIssuesMatching }
+        option("Search by priority") { noIssuesMatching }
+        option("Display all issues") { displayAllIssuesMenu }
+        option("Display all issues satisfying filter") { noIssuesMatching }
+    }
+
+internal val issuesMenu = mkIssuesMenu()
+
+fun mainIssuesMenu() {
+    val t = Terminal()
+    var currentScreen: Screen? = issuesMenu
+
+    while (currentScreen != null) {
+        t.printLine()
+        t.printLine("/\\".repeat(40))
+        t.printLine()
+
+        currentScreen = currentScreen.run(t)
+    }
+}

--- a/src/main/kotlin/anttracker/issues/Screen.kt
+++ b/src/main/kotlin/anttracker/issues/Screen.kt
@@ -1,0 +1,77 @@
+package anttracker.issues
+
+interface Screen {
+    fun run(t: Terminal): Screen?
+}
+
+fun screenWithMenu(config: ScreenWithMenu.() -> Unit): Screen {
+    val menu = ScreenWithMenu()
+    config(menu)
+    return menu
+}
+
+typealias ScreenHandler = () -> Screen
+
+typealias DisplayFn = (t: Terminal) -> Any?
+
+open class ScreenWithMenu : Screen {
+    private var menuTitle: String = ""
+    private var options: Map<String, ScreenHandler> = mutableMapOf()
+    private var displayContent: DisplayFn = { }
+    private var promptMessage: String = ""
+
+    fun title(theTitle: String) {
+        this.menuTitle = theTitle
+    }
+
+    fun option(
+        description: String,
+        handler: () -> Screen,
+    ) {
+        this.options += description to handler
+    }
+
+    fun promptMessage(message: String) {
+        this.promptMessage = message
+    }
+
+    override fun run(t: Terminal): Screen? {
+        val byIndex = displayMenu(t)
+
+        t.printLine()
+        displayContent(t)
+        t.printLine()
+
+        // Ask the user to enter which menu wants to select
+        val mainMenuChoice = "`"
+        val backToMainMenuMessage = " `(backtick) to abort:"
+        val choices = (1..byIndex.size).map(Integer::toString) + mainMenuChoice
+        // The user needs to choose from the choices that are `, 1, 2, 3, 4...
+        val response = t.prompt(promptMessage + backToMainMenuMessage, choices = choices)
+
+        return when (response) {
+            mainMenuChoice -> null
+            else -> {
+                val index = Integer.parseInt(response)
+                byIndex[index - 1].value()
+            }
+        }
+    }
+
+    private fun displayMenu(t: Terminal): Array<Map.Entry<String, ScreenHandler>> {
+        val byIndex = options.entries.toTypedArray()
+
+        t.printLine("== $menuTitle ==")
+        byIndex.forEachIndexed { index, entry ->
+            val nbr = "${index + 1}".padStart(2, ' ')
+            t.print(nbr)
+            t.printLine(". ${entry.key}")
+        }
+
+        return byIndex
+    }
+
+    fun content(fn: DisplayFn) {
+        displayContent = fn
+    }
+}

--- a/src/main/kotlin/anttracker/issues/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/issues/SetupSchema.kt
@@ -90,15 +90,6 @@ class Issue(
     var priority by Issues.priority
 }
 
-data class Issue1(
-    val id: Long,
-    val description: String,
-    val priority: Priority,
-    val fixBy: ReleaseId?,
-) {
-    val status: IssueStatus = IssueStatus.Triage
-}
-
 sealed class Priority {
     data object High : Priority()
 

--- a/src/main/kotlin/anttracker/issues/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/issues/SetupSchema.kt
@@ -1,0 +1,137 @@
+package anttracker.issues
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.javatime.CurrentDateTime
+import org.jetbrains.exposed.sql.javatime.datetime
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.*
+
+fun setupSchema() {
+    transaction {
+        SchemaUtils.createMissingTablesAndColumns(Products, Issues, Releases)
+
+        (0..10).forEach { id ->
+            val productId = Products.insert { it[name] = "Product $id" } get Products.id
+            val relId =
+                Releases.insert {
+                    it[product] = productId
+                    it[releaseId] = "$id"
+                    it[releaseDate] = CurrentDateTime
+                } get Releases.id
+
+            val end =
+                when (id % 2) {
+                    0 -> "has"
+                    else -> "is"
+                }
+            Issues.insert {
+                it[description] = "Issue $id $end"
+                it[product] = productId
+                it[status] = "done"
+                it[priority] = 1
+                it[creationDate] = CurrentDateTime
+                it[anticipatedRelease] = relId
+            }
+        }
+    }
+}
+
+object Products : IntIdTable() {
+    val name = varchar("name", 50)
+}
+
+class Product(
+    id: EntityID<Int>,
+) : IntEntity(id) {
+    companion object : IntEntityClass<Product>(Products)
+
+    var name by Products.name
+}
+
+object Releases : IntIdTable() {
+    val releaseId = varchar("release_id", 8)
+    val product = reference("product", Products)
+    val releaseDate = datetime("release_date")
+}
+
+class Release(
+    id: EntityID<Int>,
+) : IntEntity(id) {
+    companion object : IntEntityClass<Release>(Releases)
+
+    var releaseId by Releases.releaseId
+    var product by Product referencedOn Releases.product
+    var releaseDate by Releases.releaseDate
+}
+
+object Issues : IntIdTable() {
+    val description = varchar("description", 30)
+    val product = reference("product", Products)
+    val anticipatedRelease = reference("release", Releases)
+    val creationDate = datetime("creation_date")
+    val status = varchar("status", 9)
+    val priority = short("priority")
+}
+
+class Issue(
+    id: EntityID<Int>,
+) : IntEntity(id) {
+    companion object : IntEntityClass<Issue>(Issues)
+
+    var description by Issues.description
+    var product by Product referencedOn Issues.product
+    var anticipatedRelease by Release referencedOn Issues.anticipatedRelease
+    var creationDate by Issues.creationDate
+    var status by Issues.status
+    var priority by Issues.priority
+}
+
+data class Issue1(
+    val id: Long,
+    val description: String,
+    val priority: Priority,
+    val fixBy: ReleaseId?,
+) {
+    val status: IssueStatus = IssueStatus.Triage
+}
+
+sealed class Priority {
+    data object High : Priority()
+
+    data object Low : Priority()
+
+    data object Medium : Priority()
+}
+
+sealed class IssueStatus {
+    data object Triage : IssueStatus()
+
+    data object Open : IssueStatus()
+
+    data object Working : IssueStatus()
+
+    data object Review : IssueStatus()
+
+    data object Closed : IssueStatus()
+}
+
+@JvmInline
+value class ReleaseId(
+    val id: UUID,
+)
+
+data class Contact(
+    val id: UUID,
+    val name: String,
+)
+
+data class Request(
+    val id: UUID,
+    val foundOn: ReleaseId,
+    val fixBy: ReleaseId?,
+    val contact: Contact,
+)

--- a/src/main/kotlin/anttracker/issues/Terminal.kt
+++ b/src/main/kotlin/anttracker/issues/Terminal.kt
@@ -5,42 +5,60 @@ Rev 1 - 2024/07/01 Original by Micah
 entry-point and main-menu of AntTracker.
  */
 
-import anttracker.issues.setupSchema
-import org.jetbrains.exposed.sql.Database
-import anttracker.contact.menu as contactMenu
-import anttracker.issues.mainIssuesMenu as issuesMenu
-import anttracker.product.menu as productMenu
-import anttracker.release.menu as releaseMenu
-import anttracker.request.menu as requestMenu
+package anttracker.issues
 
-fun main() {
-    Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
-    setupSchema()
-    while (true) {
-        val mainMenuText =
-            """
-            == MAIN MENU ==
-            1   View/Edit Issue
-            2   New request
-            3   New release
-            4   New contact
-            5   New product
-            
-            Please select a command. ` to exit program: 
-            """.trimIndent()
-        print(mainMenuText)
+class Terminal {
+    fun printLine() = println()
 
-        when (val selection = readln()) {
-            "`" -> break
-            "1" -> issuesMenu()
-            "2" -> requestMenu()
-            "3" -> releaseMenu()
-            "4" -> contactMenu()
-            "5" -> productMenu()
-            else -> {
-                println("Bad input: $selection.")
+    fun printLine(text: String) {
+        println(text)
+    }
+
+    fun prompt(
+        message: String,
+        choices: List<String>,
+    ): String {
+        println(message)
+        val choice = readln()
+        if (choices.contains(choice)) {
+            return choice
+        }
+        return prompt(message, choices)
+    }
+
+    fun print(message: String) = kotlin.io.print(message)
+
+    private val formatter = DateTimeFormatter.ofPattern("yyyy/mm/dd")
+
+    fun displayTable(
+        columns: List<Pair<String, Int>>,
+        rows: List<List<Any>>,
+    ) {
+        columns
+            .joinToString(separator = " |", postfix = "|", prefix = "|") { (columnName, length) ->
+                columnName.padEnd(length)
+            }.let {
+                print("# ")
+                printLine(it)
             }
+
+        rows.forEachIndexed { index, row ->
+            val stringRow =
+                row
+                    .mapIndexed { colIndex, col ->
+                        val length = columns[colIndex].second
+                        when {
+                            (col is Number) -> col.toString().padEnd(length)
+                            (col is LocalDateTime) -> col.format(formatter).padEnd(length)
+                            (col is LocalDate) -> col.format(formatter).padEnd(length)
+                            else -> col.toString().padEnd(length)
+                        }
+                    }.joinToString(separator = " |", postfix = "|", prefix = "|")
+            printLine("${(index + 1).toString().padEnd(2)}$stringRow")
         }
     }
 }


### PR DESCRIPTION
## Summary

The user selects to view all issues once they are within the issues menu and sees the first 20 issues.

The issues will appear like this.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/7f824b89-2192-44a1-993a-e4b8914ff008">

closes #35 


## Changes

### src/main/kotlin/anttracker/issues/SetupSchema.kt
* Added the schema for `Contact`, `Issue`, `Release`, and `Product`

### build.gradle.kts
* Added dependencies for `Exposed`

### src/main/kotlin/anttracker/issues/Issues.kt
* Added `displayAllIssuesMenu` which shows all the issues from the database
* Added `mkIssuesMenu` which generates the issues menu

### src/main/kotlin/anttracker/issues/Screen.kt
* Changed `ScreenWithMenu` so it can take a customized prompt 

### src/main/kotlin/anttracker/Main.kt
* Added schema creation to the start of the program

