### PR TITLE
Tyrus request and page of

### DIFF
--- a/src/main/kotlin/anttracker/PageOf.kt
+++ b/src/main/kotlin/anttracker/PageOf.kt
@@ -1,0 +1,124 @@
+package anttracker
+import anttracker.release.Release
+import anttracker.release.ReleaseTable
+import org.jetbrains.exposed.sql.Query
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.math.ceil
+
+// A PageOf objects contains a max-20 element list of T.
+// Provides top-level functionality for:
+//  - loading DB records into memory (one page at a time)
+//  - displaying page contents
+//  - going to the next page and loading its records
+abstract class PageOf<T> {
+    protected var contents: MutableList<T> = mutableListOf() // Container for object instances
+    protected var pagenum: Int = 0 // NOTE: Page numbers are 0-indexed
+    protected var lastPageNum: Int = 0
+    protected val OFFSET: Int = 0 // For page calculation in DB query
+    protected val LIMIT: Int = 20 // Number of records per page.
+
+    // -------------------------------------------------------------------------------
+    // Automatically called upon object creation (i.e. a ctor)
+    // Inherited in PageOf implementations.
+    // ---
+    init {
+        initLastPageNum()
+    }
+
+    // -------------------------------------------------------------------------------
+    // Prints to console a line-by-line display of objects contained in the PageOf instance.
+    // Abstract/Virtual as issues, releases, contacts will display different things.
+    // ---
+    abstract fun display()
+
+    // -------------------------------------------------------------------------------
+    // Queries to DB and pulls a maximum 20 records at a time into the MutableList contents datamember.
+    // ---
+    fun loadContents() {
+        contents.clear()
+        val queryOutput = queryToDB()
+        queryOutput.forEach {
+            contents.add(it[ReleaseTable])
+        }
+    }
+
+    // -------------------------------------------------------------------------------
+    // Increments page number and loads associated DB records into MutableList contents datamember
+    // Throws an error if attempting to load beyond the last page.
+    // ---
+    fun loadNextPage() {
+        if (lastPage()) {
+            throw Exception("PageOf: Already reached last page.")
+        }
+        pagenum++
+        loadContents()
+    }
+
+    // -------------------------------------------------------------------------------
+    // TRUE if current page >= than the last page.
+    // ---
+    fun lastPage(): Boolean = pagenum >= lastPageNum
+
+    // -------------------------------------------------------------------------------
+    // Used in init/ctor block to calculate the last page number.
+    // As we are 0-indexing the page numbers, we subtract 1 at the end.
+    // ---
+    fun initLastPageNum() {
+        lastPageNum =
+            ceil(
+                (getQueryRowCount().toDouble() / LIMIT.toDouble()),
+            ).toInt() - 1
+    }
+
+    // -------------------------------------------------------------------------------
+    // Returns the total number of rows/records of the query being paginated.
+    // Used for calculating the number of pages the query needs.
+    // Abstract/Virtual as query needs to be defined per PageOf Type
+    // ---
+    protected abstract fun getQueryRowCount(): Int
+
+    // -------------------------------------------------------------------------------
+    // Defines the DAO query to DB used to pull records into memory.
+    // Abstract/Virtual as query needs to be defined per PageOf Type
+    // ---
+    protected abstract fun queryToDB(): Query
+}
+
+// -------------------------------------------------------------------------------
+// Implementation of a PageOf Class as PageOfReleases
+// Each PageOf class needs to define:
+//      - display(), to define how the page is displayed to console
+//      - getQueryRowCount(), to calculate the last page number
+//      - queryToDB(), to define the DAO query to DB used to pull records into memory
+// ---
+class PageOfReleases(
+    private val productName: String,
+) : PageOf<ReleaseTable>() {
+    override fun display() {
+        for (releaseRecord in contents) {
+            println(releaseRecord.releaseID)
+        }
+    }
+
+    override fun getQueryRowCount(): Int {
+        var numRecords = 0
+        transaction {
+            numRecords = ReleaseTable.count()
+        }
+        return numRecords
+    }
+
+    override fun queryToDB() {
+        var output: Query
+        transaction {
+            output =
+                Release
+                    .find {
+                        ReleaseTable.product eq productName
+                    }.limit(LIMIT)
+                    .offset(pagenum * LIMIT + OFFSET)
+        }
+        return output
+    }
+}

--- a/src/main/kotlin/anttracker/PageOf.kt
+++ b/src/main/kotlin/anttracker/PageOf.kt
@@ -43,7 +43,7 @@ abstract class PageOf<IntEntity> {
     }
 
     // -------------------------------------------------------------------------------
-    // Queries to DB and pulls a page of records (max 20) into the contents MutableList.
+    // Queries to DB and pulls a page of records (max 20) into the records MutableList.
     // ---
     fun loadRecords() {
         records.clear()
@@ -60,15 +60,15 @@ abstract class PageOf<IntEntity> {
     // -------------------------------------------------------------------------------
     // Returns the size/length of the records MutableList.
     // ---
-    fun contentsSize(): Int = records.size
+    fun recordsSize(): Int = records.size
 
     // -------------------------------------------------------------------------------
-    // Getter for elements in the contents MutableList.
+    // Getter for elements in the records MutableList.
     // ---
     fun getContentAt(index: Int): IntEntity = records[index]
 
     // -------------------------------------------------------------------------------
-    // Increments page number and loads associated DB records into MutableList contents datamember
+    // Increments page number and loads associated DB records into records MutableList
     // Throws an error if attempting to load beyond the last page.
     // ---
     fun loadNextPage() {

--- a/src/main/kotlin/anttracker/Product.kt
+++ b/src/main/kotlin/anttracker/Product.kt
@@ -8,6 +8,7 @@ the creation or selection of product entities.
 */
 
 package anttracker.product
+import anttracker.issues.Product
 
 // ----------------------------------------------------------------------------
 // Class for storing the attributes of a given product.
@@ -31,6 +32,10 @@ value class Product(
 //   "1"...: selected row
 // ---
 fun displayProducts(): String {
+    TODO()
+}
+
+fun selectProduct(): Product? {
     TODO()
 }
 

--- a/src/main/kotlin/anttracker/Product.kt
+++ b/src/main/kotlin/anttracker/Product.kt
@@ -14,7 +14,7 @@ import anttracker.issues.Product
 // Class for storing the attributes of a given product.
 // ---
 @JvmInline
-value class Product(
+value class ProductName(
     private val name: String, // name of the product (primary key)
 ) {
     init {

--- a/src/main/kotlin/anttracker/Product.kt
+++ b/src/main/kotlin/anttracker/Product.kt
@@ -8,7 +8,7 @@ the creation or selection of product entities.
 */
 
 package anttracker.product
-import anttracker.issues.Product
+import anttracker.Product
 
 // ----------------------------------------------------------------------------
 // Class for storing the attributes of a given product.
@@ -29,10 +29,6 @@ value class ProductName(
 // Implements pagination when necessary.
 // Returns the product selected by the user, or null if the user changed their mind.
 // ---
-fun selectProduct(): Product? {
-    TODO()
-}
-
 fun selectProduct(): Product? {
     TODO()
 }

--- a/src/main/kotlin/anttracker/Release.kt
+++ b/src/main/kotlin/anttracker/Release.kt
@@ -80,14 +80,14 @@ fun selectRelease(
         println(promptSelectRel) // "Please select release. ` to abort: "
         val userInput = readln()
         when (userInput) {
-            "`" -> return null
-            "" -> {
+            "`" -> return null // User wants to abort
+            "" -> { // User wants to see next page of product releases
                 if (!relPage.lastPage()) {
                     relPage.loadNextPage()
                     relPage.display()
                 }
             }
-            else -> {
+            else -> { // User has attempted to enter a line number
                 try {
                     val userInputInt = userInput.toInt()
                     if (userInputInt in (1..20) && userInputInt < relPage.recordsSize()) {

--- a/src/main/kotlin/anttracker/Release.kt
+++ b/src/main/kotlin/anttracker/Release.kt
@@ -61,7 +61,7 @@ fun menu() {
 // ---
 fun displayReleases(productName: String) {
     val relPage = PageOfReleases(productName)
-    relPage.loadContents()
+    relPage.loadRecords()
     relPage.display()
 
     while (!relPage.lastPage()) {
@@ -79,7 +79,7 @@ fun displayReleases(productName: String) {
 
 fun selectRelease(productName: String): Release? {
     val relPage = PageOfReleases(productName)
-    relPage.loadContents()
+    relPage.loadRecords()
     relPage.display()
 
     var linenum: Int? = null
@@ -97,7 +97,7 @@ fun selectRelease(productName: String): Release? {
             else -> {
                 try {
                     val userInputInt = userInput.toInt()
-                    if (userInputInt in (1..20) && userInputInt < relPage.contentsSize()) {
+                    if (userInputInt in (1..20) && userInputInt < relPage.recordsSize()) {
                         linenum = userInput.toInt()
                     }
                 } catch (e: java.lang.NumberFormatException) {

--- a/src/main/kotlin/anttracker/Release.kt
+++ b/src/main/kotlin/anttracker/Release.kt
@@ -11,10 +11,10 @@ The module hides validation of release attributes, the interactive menu prompts 
 
 package anttracker.release
 import anttracker.PageOf
-import anttracker.issues.Product
-import anttracker.issues.Products
-import anttracker.issues.Release
-import anttracker.issues.Releases
+import anttracker.Product
+import anttracker.Products
+import anttracker.Release
+import anttracker.Releases
 import anttracker.product.selectProduct
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.SortOrder
@@ -147,6 +147,7 @@ value class ReleaseId(
             "Release id length must be between 1 and 8 characters"
         }
     }
+
     override fun toString(): String = id
 }
 
@@ -212,6 +213,7 @@ class PageOfReleases(
         }
         return output
     }
+}
 
 val promptEnterRel = "\nPlease enter new release name. ` to abort:"
 

--- a/src/main/kotlin/anttracker/Release.kt
+++ b/src/main/kotlin/anttracker/Release.kt
@@ -10,9 +10,31 @@ The module hides validation of release attributes, the interactive menu prompts 
 */
 
 package anttracker.release
-
 import anttracker.product.Product
+import anttracker.product.displayProducts
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDate
+
+
+object ProductTable : Table("product") {
+    val productName = varchar("productName", 10)
+    override val primaryKey = PrimaryKey(productName)
+}
+
+object ReleaseTable : Table("release") {
+    val releaseID = varchar("releaseID", 8)
+    val product =
+        varchar("product", 10).references(
+            ProductTable.productName,
+            onDelete = ReferenceOption.CASCADE,
+            onUpdate = ReferenceOption.CASCADE,
+        )
+    val releaseDate = varchar("releaseDate", 10)
+    override val primaryKey = PrimaryKey(arrayOf(releaseID, product))
+}
 
 @JvmInline
 value class ReleaseId(
@@ -23,6 +45,20 @@ value class ReleaseId(
             "Release id length must be between 1 and 8 characters"
         }
     }
+
+    override fun toString(): String = id
+}
+
+fun testProducts() {
+    var linenum = 1
+    transaction {
+        val output = ProductTable.selectAll()
+        println("Product List")
+        output.forEach {
+            println("$linenum   ${it[ProductTable.productName]}")
+            linenum++
+        }
+    }
 }
 
 class Release(
@@ -31,13 +67,30 @@ class Release(
     var releaseDate: LocalDate,
 )
 
+val promptEnterRel = "\nPlease enter new release name. ` to abort:"
+
+val promptSelectRel = "\nPlease select release. ` to abort:"
+
+val promptSelectAffRel = "\nPlease select affected release. ` to abort:"
+
 // -------------------------------------------------------------------------------
 // Prints a sub-menu of selecting a product to create a release for.
 // Use by including in main-menu loop; should be triggered upon user selecting
 // New Release from the main menu. Thus, upon function return, system returns to main menu.
 // ---
 fun menu() {
-    TODO()
+    println("== NEW RELEASE ==")
+    println("should be some product list below:")
+    testProducts()
+    println("\nPlease select a product (1). ` to abort:")
+    when (val selection = readln()) {
+        "`" -> return
+        "1" -> createRelease()
+        else -> {
+            println("Bad input: $selection.")
+            return
+        }
+    }
 }
 
 // -------------------------------------------------------------------------------
@@ -51,5 +104,145 @@ fun menu() {
 fun displayReleases(
     product: String, // in
 ): String {
-    TODO()
+    println("$product releases:")
+    transaction {
+        val output = ReleaseTable.selectAll().where { ReleaseTable.product eq product }
+    }
+    return product
 }
+
+fun selectRelease(productName: String? = null): Release? {
+    var product = productName
+    if (product == null) {
+        product = selectProduct()
+    }
+
+    while (!userinput) {
+        displayReleases(product)
+    }
+
+    transaction {
+//            release = ReleaseTable.selectAll().where {
+//                ReleaseTable.product eq productName and
+//                ReleaseTable.releaseID eq releaseID
+//            }
+    }
+    return release
+}
+
+fun createRelease() {
+    displayReleases("GreenTiger")
+
+    var linenum: Int? = null
+    while (linenum == null) {
+        println(promptSelectRel)
+        val selection = readln()
+        if (selection == "`") {
+            return
+        }
+        try {
+            val userEntry = selection.toInt()
+            when (userEntry) {
+                in 0..20 -> linenum = userEntry
+                else -> {
+                    println("Error: please enter a valid line number.")
+                }
+            }
+        } catch (e: java.lang.NumberFormatException) {
+            println("Error: please enter a number.")
+        }
+    }
+
+    // val selectedProduct: String = linenum.toString()
+    val selectedProduct: String = displayProducts(selectedProduct)
+    displayReleases(selectedProduct)
+
+    var releaseEntry: String? = null
+    while (releaseEntry == null) {
+        println(promptEnterRel)
+        try {
+            releaseEntry = ReleaseId(readln()).toString()
+            if (releaseEntry == "`") {
+                return
+            }
+        } catch (e: java.lang.IllegalArgumentException) {
+            println(e.message)
+        }
+    }
+    // if saveToDb()
+    println("$selectedProduct $releaseEntry created.\n")
+}
+
+/*
+NOTE: 95% complete pseudocode
+
+SQL for getting a page of release records from full query output:
+select * from Release where
+    product = $product
+    LIMIT 20 OFFSET (pagenum*limit + offset)
+
+--PageOf<T>--
+contents:       MutableList<T>
+pagenum:        Int = 0 // decide on 0 or 1 indexed?
+lastPageNum:    Int = 0 // initialized on construct/init
+offset:         Int = 0
+limit:          Int = 20
+
+--PageOf<Release>--
+// added data:
+product: String
+
+// Prints page contents to terminal
+display() {
+    for releaseRecord in contents
+        println(releaseRecord.releaseID)  // add some nice formatting
+}
+
+// Stores page with its associated records in DB
+
+
+loadNextPage() {
+    if (lastPage()) {
+        throw exception
+    }
+    pagenum++;
+    loadContents()
+}
+
+//EXAMPLE:
+//    Total query returns 30 rows = 2 pages (20 + 10)
+//    pagelimit is 20, 30/20 = 1.5
+//    ceil(1.5) = 2
+//    therefore, maxPages = ceil(count(Qtotal)/limit)
+initLastPageNum() {
+
+}
+
+// Displays pages of releases to console, prompts user to select one with linenumber.
+// Returns user-selected release record from page.
+selectRelease(product: String)
+    relPage: PageOf<Release>(product)
+    relPage.loadContents()
+    relPage.display()
+
+    linenum: LineNum? = null
+    while(!linenum) {
+        println(promptRelSelect) //"Please select release. ` to abort: "
+        userInput = readln()
+        when (userInput) {
+            "`" -> return
+            <Enter> -> {
+                if (!lastPage()) {
+                    loadNextPage()
+                }
+            }
+            else {
+                if userInput is valid linenumber (1..20 AND < contents.size())
+                    linenum = userInput
+                else
+                    println(errMsgInvalidLineNum) // While loop continues; user can try again
+            }
+        }
+    }
+    return releasePage.contents.get(linenum)
+*/

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -24,6 +24,7 @@ import anttracker.issues.selectIssue
 
 // product imports
 import anttracker.product.selectProduct
+import anttracker.product.ProductName
 
 // release imports
 import anttracker.Issue
@@ -91,9 +92,10 @@ fun getRequestInfo(
 //     input when necessary, re-prompting where necessary.
 // Returns the created request.
 fun enterRequestInformation(): Request? {
+    TODO("Convert to DAO operations. Should remove the data class for Request. -Tyrus ")
     // "?:" is a check if selectProduct returns null
     val product = selectProduct() ?: return null
-    val release = selectRelease(product) ?: return null
+    val release = selectRelease(product.name) ?: return null
 
     var contact = selectContact()
 
@@ -103,7 +105,7 @@ fun enterRequestInformation(): Request? {
     }
 
     // filter available issues with product
-    val issueFilter = IssueFilter.ByProduct(product = product)
+    val issueFilter = IssueFilter.ByProduct(ProductName(product.name))
 
     // NOTE: implement constant somewhere for "issuesPerPage"
     var issue = selectIssue(issueFilter, 20)
@@ -117,18 +119,21 @@ fun enterRequestInformation(): Request? {
     }
 
     // construct request object
-    val request =
-        Request(
-            release.id,
-            issue,
-            contact.name,
-            LocalDate.now(),
-        )
+    // TODO: replace with DAO insert operation Request.new { ... } -Tyrus
+//    val request =
+//        Request(
+//            release.id,
+//            issue,
+//            contact.name,
+//            LocalDate.now(),
+//        )
 
     // save the request object into the DB
-    saveRequest(request)
+    // saveRequest(request)
 
-    return request
+    // return request
+    // TODO: replaced with return null until insert operation is updated. -Tyrus
+    return null
 }
 
 // Displays a sub-menu for selecting an existing request.

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -10,8 +10,7 @@ and searching for issues are also present in this file.
  */
 
 package anttracker.issues
-
-import anttracker.product.Product
+import anttracker.product.ProductName
 import anttracker.release.ReleaseId
 import anttracker.request.Request
 
@@ -30,7 +29,7 @@ value class Description(
 
 data class IssueInformation(
     val description: Description,
-    val productName: Product,
+    val productName: ProductName,
     val affectedRelease: ReleaseId,
     val anticipatedRelease: ReleaseId? = null,
     val priority: Priority,
@@ -92,7 +91,7 @@ sealed class IssueFilter {
     ) : IssueFilter()
 
     data class ByProduct(
-        val product: Product,
+        val product: ProductName,
     ) : IssueFilter()
 
     data class Composite(


### PR DESCRIPTION
# Summary
Implements the release module, as well as the PageOf module for primitive pagination abstraction.
The release module currently depends on a **selectProduct()** function that isn't written yet; this returns a string indicating a product name. This name is used to retrieve releases from the database. I've put a TODO() in this function in the product module.

# Changes
**Release.kt**
- removed the old definition of the Release object (now uses Eitan's schema definition)
- displayReleases() is now just a read-only display of product releases (used when creating a new release, first displays the list of existing releases to the user)
- selectRelease(productName) displays a paginated list of product releases to the user. The user selects one by line number. The function returns the release entity associated with the line number.

---

**PageOf.kt**
Wrote module implementing pagination of database queries. Currently describes the abstract class PageOf, and a sub-class PageOfReleases to demonstrate how to implement PageOf for other record types.
Implementing a PageOf subclass only requires implementation of just 2 abstract functions + 1 init block:
1. init block - calls initLastPageNum(). must be done in subclass to ensure it is called AFTER subclass prop initialization
2. printRecord() - define how to print a single record to console
3. getQuery() - the actual DAO query to retrieve records from the DB

Once those have been implemented, you can use a PageOf instance as loosely follows:

```
val page: PageOfSubclass
page.loadRecords() // This loads the first page's records from DB to memory
page.display() // This prints the currently loaded page records to console
page.nextPage() // This will clear old page records and fill with the next page's records from DB to memory
page.display() // This displays the next page's records
```

For how to implement this into a user-prompt menu loop, have a look at selectRelease().