### PR TITLE
Implement the rest of the Request module

### DIFF
--- a/src/main/kotlin/anttracker/Contact.kt
+++ b/src/main/kotlin/anttracker/Contact.kt
@@ -9,6 +9,8 @@ The Contact module contains all exported classes and functions pertaining to
 
 package anttracker.contact
 
+import anttracker.db.Contact
+
 // ----------------------------------------------------------------------------
 
 @JvmInline

--- a/src/main/kotlin/anttracker/Contact.kt
+++ b/src/main/kotlin/anttracker/Contact.kt
@@ -61,15 +61,6 @@ value class Department(
     }
 }
 
-// Data class for storing the attributes of a given contact.
-// ---
-data class Contact(
-    val name: Name,
-    val email: Email,
-    val phoneNumber: PhoneNumber,
-    val department: Department
-)
-
 // ----------------------------------------------------------------------------
 // Displays a sub-menu for creating a new contact and adding it to the
 //     AntTracker database.

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -25,7 +25,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
 
 // display a given request to the screen
-fun displayRequest(request: Request?) {
+fun displayRequester(request: Request?) {
     if (request == null) {
         println("Error: Bad request")
         return // bad request
@@ -92,7 +92,7 @@ fun enterRequestInformation(): Request? {
 
     println("Created request:")
     println("AffRel\tRequested\tName\tEmail\tDepartment")
-    displayRequest(request)
+    displayRequester(request)
 
     return request
 }

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -1,6 +1,7 @@
 /* Revision History:
 Rev. 1 - 2024/07/02 Original by A. Kim
 Rev. 2 - 2024/07/09 by M. Baker
+Rev. 3 - 2024/07/16 by M. Baker
 -------------------------------------------------------------------------------
 The Request module contains all exported classes and functions pertaining to
     the creation or selection of request entities.
@@ -9,13 +10,9 @@ The Request module contains all exported classes and functions pertaining to
 package anttracker.request
 
 import anttracker.contact.enterContactInformation
-import anttracker.contact.getContactInfo
-import anttracker.contact.Name
 import anttracker.contact.selectContact
-import anttracker.db.Issue
-import anttracker.issues.Days
+import anttracker.db.*
 import anttracker.issues.IssueFilter
-import anttracker.issues.IssueId
 import anttracker.issues.enterIssueInformation
 import anttracker.issues.saveIssue
 import anttracker.issues.selectIssue
@@ -23,61 +20,31 @@ import anttracker.product.selectProduct
 import anttracker.product.ProductName
 
 // release imports
-import anttracker.release.ReleaseId
 import anttracker.release.selectRelease
-import java.time.LocalDate
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.time.LocalDateTime
 
-// ----------------------------------------------------------------------------
-// Data class for storing the attributes of a given request.
-// ---
-data class Request(
-    val affectedRelease: ReleaseId,
-    val issue: Issue,
-    val contact: Name,
-    val requestDate: LocalDate,
-)
+// display a given request to the screen
+fun displayRequest(request: Request?) {
+    if (request == null) {
+        return
+    }
 
-// any attribute in this may be null - signifying a not being used filtering mechanism
-// only non-null attributes of this class may be considered in the filtering process
-data class RequestFilter(
-    val name: Name?, // by contact name
-    val days: Days?, // since n days
-    val release: ReleaseId?, // by release
-    val issue: IssueId?, // by issue
-)
+    var contact: Contact? = null
 
-// -----------------
+    // get full information about this contact
+    transaction {
+        contact = Contact.find { Contacts.id eq request.contact }.firstOrNull()
+    }
 
-// ---- database functions
+    val affRel = request.affectedRelease
+    val date = request.requestDate
+    val name = contact.name
+    val email = contact.email
+    val dept = contact.department
 
-// saves a given request object into the database
-fun saveRequest(
-    request: Request, // in
-) {
-    TODO()
+    println("$affRel\t$date\t$name\t$email\t$dept")
 }
-
-// gets the next $limit requests from the DB after the $offset according to the $filter
-// returns an empty list if there are no more requests to display
-// if $filter is null, then retrieve all requests, ordered by the primary key
-fun getRequestsInDB(
-    offset: Int,
-    limit: Int,
-    filter: RequestFilter?,
-): List<Request> {
-    TODO()
-}
-
-// Returns all information about the request identified by the issueID.
-// Returns null if not found
-fun getRequestInfo(
-    requester: String, // in
-    issueID: Int, // in
-): Request? {
-    TODO()
-}
-
-// ---- menu functions
 
 // Displays a sub-menu for creating a new request and adding it to the
 //     AntTracker database.
@@ -85,7 +52,6 @@ fun getRequestInfo(
 //     input when necessary, re-prompting where necessary.
 // Returns the created request.
 fun enterRequestInformation(): Request? {
-    TODO("Convert to DAO operations. Should remove the data class for Request. -Tyrus ")
     // "?:" is a check if selectProduct returns null
     val product = selectProduct() ?: return null
     val release = selectRelease(product.name) ?: return null
@@ -107,117 +73,24 @@ fun enterRequestInformation(): Request? {
         val issueInformation = enterIssueInformation() ?: return null
 
         // if this returns null, then return null -- error occurred
-        // TODO: print an error?
         issue = saveIssue(issueInformation) ?: return null
     }
 
-    // construct request object
-    // TODO: replace with DAO insert operation Request.new { ... } -Tyrus
-//    val request =
-//        Request(
-//            release.id,
-//            issue,
-//            contact.name,
-//            LocalDate.now(),
-//        )
+    var request: Request? = null
 
-    // save the request object into the DB
-    // saveRequest(request)
-
-    // return request
-    // TODO: replaced with return null until insert operation is updated. -Tyrus
-    return null
-}
-
-// Displays a sub-menu for selecting an existing request.
-// Implements pagination when necessary.
-// Returns the selected request, or null if user chooses to leave the menu.
-fun selectRequest(
-    filter: RequestFilter?, // in
-): Request? {
-    var offset = 0 // TODO: make this a global constant, for use by multiple modules
-    val limit = 20
-
-    while (true) {
-        // get next $limit requests from the DB, after the $offset, according to the $filter
-        val retrievedRequests = getRequestsInDB(offset, limit, filter)
-        var isNoMore = retrievedRequests.size < limit
-
-        // check that there aren't any more requests to display
-        if (retrievedRequests.isEmpty()) {
-            if (offset != 0) {
-                // end of listings reached; print last $limit requests instead.
-                offset -= limit
-
-                if (offset < 0) {
-                    offset = 0
-                }
-
-                isNoMore = true
-            } else {
-                // no requests stored in the DB yet
-                println("There are no requests to select.")
-                return null
-            }
-        }
-
-        // TODO: make columns spaced evenly among listing - could involve pre-construction
-        //       of the individual cells as strings, and computing the maximum size per column
-        //       to set that column's width in characters - possible implemented in a UI.kt file
-        println("AffRel\tRequested\tName\tEmail\tDepartment")
-
-        for (request in retrievedRequests) {
-            // get the contact information given their name (for email, dept)
-            val contact = getContactInfo(request.contact)
-
-            // print a line for this request
-            println(
-                "${request.affectedRelease}\t" +
-                    "${request.requestDate}\t" +
-                    "${request.contact}\t" +
-                    "${contact.email}\t" +
-                    "${contact.department}\t",
-            )
-        }
-
-        if (isNoMore) {
-            println("...")
-            println("There are no more requests to be listed.")
-        }
-
-        println()
-        println("Please select a request. <Enter> to view $limit more requests. ` to abort: ")
-
-        // read input from user
-        when (val selection = readln()) {
-            "`" -> return null // chose to exit menu
-            "" -> {
-                if (!isNoMore) {
-                    offset += limit
-                }
-
-                // continue - re-list the requests.
-                // isNoMore should still be true, and the "No more" message will be listed.
-            } // next page (enter key - empty string)
-            else -> {
-                try {
-                    // attempt to select a row
-                    val row = selection.toInt()
-
-                    if (row < 0 || row >= limit) {
-                        println("error")
-                        continue
-                    }
-
-                    // row was selected - so was the request
-                    return retrievedRequests[row]
-                } catch (e: NumberFormatException) {
-                    println("error")
-                    continue
-                }
-            }
+    transaction {
+        request = Request.new {
+            this.affectedRelease = release.id
+            this.issue = issue.id
+            this.contact = contact.id
+            this.requestDate = LocalDateTime.now()
         }
     }
+
+    println("Created request:")
+    displayRequest(request)
+
+    return request
 }
 
 // Displays a sub-menu for creating a new request and adding it to the

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -27,14 +27,18 @@ import java.time.LocalDateTime
 // display a given request to the screen
 fun displayRequest(request: Request?) {
     if (request == null) {
-        return
+        println("Error: Bad request")
+        return // bad request
     }
 
-    var contact: Contact? = null
-
     // get full information about this contact
-    transaction {
-        contact = Contact.find { Contacts.id eq request.contact }.firstOrNull()
+    val contact = transaction {
+        Contact.find { Contacts.id eq request.contact }.firstOrNull()
+    }
+
+    if (contact == null) {
+        println("Error: Bad contact for request")
+        return // bad contact
     }
 
     val affRel = request.affectedRelease
@@ -52,7 +56,6 @@ fun displayRequest(request: Request?) {
 //     input when necessary, re-prompting where necessary.
 // Returns the created request.
 fun enterRequestInformation(): Request? {
-    // "?:" is a check if selectProduct returns null
     val product = selectProduct() ?: return null
     val release = selectRelease(product.name) ?: return null
 
@@ -88,6 +91,7 @@ fun enterRequestInformation(): Request? {
     }
 
     println("Created request:")
+    println("AffRel\tRequested\tName\tEmail\tDepartment")
     displayRequest(request)
 
     return request

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -1,3 +1,10 @@
+/* Revision History:
+Rev. 1 - 2024/07/02 Original by E. Barylko
+Rev. 2 - 2024/07/09 by T. Tracey
+Rev. 3 - 2024/07/16 by M. Baker
+^^^ what are the correct dates???
+ */
+
 package anttracker.db
 
 import org.jetbrains.exposed.dao.IntEntity
@@ -12,7 +19,7 @@ import java.util.*
 
 fun setupSchema() {
     transaction {
-        SchemaUtils.createMissingTablesAndColumns(Products, Issues, Releases)
+        SchemaUtils.createMissingTablesAndColumns(Products, Issues, Releases, Requests, Contacts)
 
         (0..5).forEach { productId ->
             val prodId = Products.insert { it[name] = "Product $productId" } get Products.id
@@ -115,14 +122,38 @@ value class ReleaseId(
     val id: UUID,
 )
 
-data class Contact(
-    val id: UUID,
-    val name: String,
-)
+object Contacts : IntIdTable() {
+    val name = varchar("name", 30)
+    val email = varchar("email", 24)
+    val phoneNumber = varchar("phone_number", 11)
+    val department = varchar("department", 12)
+}
 
-data class Request(
-    val id: UUID,
-    val foundOn: ReleaseId,
-    val fixBy: ReleaseId?,
-    val contact: Contact,
-)
+class Contact(
+    id: EntityID<Int>,
+) : IntEntity(id) {
+    companion object : IntEntityClass<Contact>(Contacts)
+
+    var name by Contacts.name
+    var email by Contacts.email
+    var phoneNumber by Contacts.phoneNumber
+    var department by Contacts.department
+}
+
+object Requests : IntIdTable() {
+    val affectedRelease = reference("release_id", Releases)
+    val issue = reference("issue_id", Issues)
+    val contact = reference("contact_id", Contacts)
+    val requestDate = datetime("request_date")
+}
+
+class Request(
+    id: EntityID<Int>,
+) : IntEntity(id) {
+    companion object : IntEntityClass<Request>(Requests)
+
+    var affectedRelease by Requests.affectedRelease
+    var issue by Requests.issue
+    var contact by Requests.contact
+    var requestDate by Requests.requestDate
+}

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -15,7 +15,7 @@ import anttracker.db.Issue
 import anttracker.db.Priority
 import anttracker.product.ProductName
 import anttracker.release.ReleaseId
-import anttracker.request.Request
+import anttracker.db.Request
 
 // ------
 


### PR DESCRIPTION
# Summary

This PR implements the remaining portions of the Request module, particularly the database functionalities.
It also cuts out functions that aren't used by other modules, that were previously written as examples and to better understand coding Kotlin.

# Changes

## Contact.kt

- Change to use the Contact entity class.
- Deleted the `data class Contact`

## Request.kt

- Deleted the `selectRequest` function. (Can be implemented in the future with PageOf, should it be needed.)
- Deleted `data class Request`, `fun getRequestsInDB`, `fun getRequestInfo`, `fun saveRequest`, and `data class RequestFilter` for lack of usefulness (not used anywhere anymore)
- Create the `displayRequest` function, perhaps to be used by Issues.kt when displaying the requests for a given issue.
  - Also used by `enterRequestInformation` when a `Request` table row is created, to display the created request
- Completed `enterRequestInformation` function using table objects and entity classes 

## SetupSchema.kt

- Added the `Contacts` table object, and `Contact` entity class
- Added the `Requests` table object, and `Request` entity class
- Changed `fun setupSchema` to initialize tables `Contacts` and `Requests`, if they don't exist

## Issue.kt

- Import `anttracker.db.Request` instead of `anttracker.request.Request` (no longer exists)

