### PR TITLE
57 - use H2 to persist the issue data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.named<JavaExec>("run") {
+    standardInput = System.`in`
+}
+
 val exposedVersion = "0.52.0"
 
 dependencies {
@@ -28,7 +32,7 @@ tasks.test {
 }
 
 application {
-    mainClass = "MainKt"
+    mainClass = "anttracker.MainKt"
 }
 
 kotlin {

--- a/src/main/kotlin/anttracker/Main.kt
+++ b/src/main/kotlin/anttracker/Main.kt
@@ -5,6 +5,8 @@ Rev 1 - 2024/07/01 Original by Micah
 entry-point and main-menu of AntTracker.
  */
 
+package anttracker
+
 import anttracker.db.setupSchema
 import org.jetbrains.exposed.sql.Database
 import anttracker.contact.menu as contactMenu
@@ -13,10 +15,38 @@ import anttracker.product.menu as productMenu
 import anttracker.release.menu as releaseMenu
 import anttracker.request.menu as requestMenu
 
-fun main() {
-    Database.connect("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+sealed class Config(
+    val db: String,
+    val shouldSetupDb: Boolean,
+) {
+    data object InMemory : Config("mem:anttracker", true)
 
-    setupSchema()
+    class PersistentWithSetup(
+        db: String,
+        shouldSetupDb: Boolean = true,
+    ) : Config(db, shouldSetupDb)
+}
+
+fun extractArgs(args: Array<String>): Config =
+    args.sorted().fold(Config.InMemory as Config) { current, param ->
+        when {
+            param.startsWith("--db=") -> Config.PersistentWithSetup(param.removePrefix("--db="), false)
+            param.startsWith("--setup") ->
+                when (current) {
+                    is Config.PersistentWithSetup -> Config.PersistentWithSetup(current.db, true)
+                    else -> current
+                }
+
+            else -> current
+        }
+    }
+
+fun main(args: Array<String>) {
+    val config = extractArgs(args)
+    Database.connect("jdbc:h2:${config.db};DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+
+    setupSchema(config.shouldSetupDb)
+
     while (true) {
         val mainMenuText =
             """

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -29,29 +29,35 @@ import org.jetbrains.exposed.sql.transactions.transaction
  * This function creates the schema for the database and adds some sample
  * products, releases, and issues.
 ---- */
-fun setupSchema() {
+fun setupSchema(shouldPopulate: Boolean) {
     transaction {
         SchemaUtils.createMissingTablesAndColumns(Products, Issues, Releases, Requests, Contacts)
 
-        (0..5).forEach { productId ->
-            val prodId = Products.insert { it[name] = "Product $productId" } get Products.id
-            (0..5).forEach { id ->
-                val relId =
-                    Releases.insert {
-                        it[product] = prodId
-                        it[releaseId] = "$id"
-                        it[releaseDate] = CurrentDateTime
-                    } get Releases.id
-                (0..20).forEach { issueId ->
+        if (shouldPopulate) {
+            populate()
+        }
+    }
+}
 
-                    Issues.insert {
-                        it[description] = "Issue $issueId"
-                        it[product] = prodId
-                        it[status] = "done"
-                        it[priority] = 1
-                        it[creationDate] = CurrentDateTime
-                        it[anticipatedRelease] = relId
-                    }
+fun populate() {
+    (0..5).forEach { productId ->
+        val prodId = Products.insert { it[name] = "Product $productId" } get Products.id
+        (0..5).forEach { id ->
+            val relId =
+                Releases.insert {
+                    it[product] = prodId
+                    it[releaseId] = "$id"
+                    it[releaseDate] = CurrentDateTime
+                } get Releases.id
+            (0..20).forEach { issueId ->
+
+                Issues.insert {
+                    it[description] = "Issue $issueId"
+                    it[product] = prodId
+                    it[status] = "done"
+                    it[priority] = 1
+                    it[creationDate] = CurrentDateTime
+                    it[anticipatedRelease] = relId
                 }
             }
         }

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -55,7 +55,7 @@ private fun editDescription(
     }
 
 /** ---
- * Updates the issue with the new description and returns
+ * Updates the issue using the function passed and returns
  * to the view issues menu.
 --- */
 private fun updateIssueAndGoBackToMenu(


### PR DESCRIPTION
## Summary

Added a function to parse arguments to determine if the user wants to use an in memory database or a file containing the data to use for the DB. 


## Changes

### src/main/kotlin/anttracker/Main.kt
* Added `extractArgs` which returns the configuration to use for setting up the DB
* Added `Config` class to represent the possible configurations to use when setting up the db

## Testing

When no arguments are passed, the DB is filled with the data from the `~/anttracker` file.

https://github.com/user-attachments/assets/0c15bfd3-259d-4f95-94d3-86ed3e563c5a

When the `--db` argument is used on a file that does not exist, the DB is empty and no issues are shown.


https://github.com/user-attachments/assets/b6f64580-f9db-4ffc-9f67-b9d9777d094a


When the `--db` argument is used on a file that does not exist together with the `--setup` option, the DB is populated with default data.


https://github.com/user-attachments/assets/cf45a4af-b0b1-445e-ab43-fe7f46599298

When the `--testing` argument is passed, an in-memory database is launched with default data

https://github.com/user-attachments/assets/1daf844d-b13b-4231-85b0-17b74cdd37e7


