### PR TITLE
59 - edit issue priority

### DIFF
--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -1,16 +1,15 @@
-/* SetupSchema.kt
-Revision History:
-Rev. 1 - 2024/07/02 Original by Eitan
-Rev. 2 - 2024/07/09 by T. Tracey
-Rev. 3 - 2024/07/16 by M. Baker
--------------------------------------------
-This file contains the schema for the
-database, defining the tables for
-products, contacts, requests, issues,
-and releases. It also contains
-a function which sets up the database.
----------------------------------
- */
+// SetupSchema.kt
+// Revision History:
+// Rev. 1 - 2024/07/02 Original by Eitan
+// Rev. 2 - 2024/07/09 by T. Tracey
+// Rev. 3 - 2024/07/16 by M. Baker
+// -------------------------------------------
+// This file contains the schema for the
+// database, defining the tables for
+// products, contacts, requests, issues,
+// and releases. It also contains
+// a function which sets up the database.
+// ---------------------------------
 
 package anttracker.db
 
@@ -41,15 +40,15 @@ fun setupSchema(shouldPopulate: Boolean) {
 }
 
 private val issueIdToStatus =
-    mapOf(
-        0 to "CREATED",
-        1 to "ASSESSED",
-        2 to "IN_PROGRESS",
-        3 to "DONE",
-        4 to "CANCELLED",
+    arrayOf(
+        Status.Created,
+        Status.Assessed,
+        Status.InProgress,
+        Status.Done,
+        Status.Cancelled,
     )
 
-private fun genStatus(id: Int): String = issueIdToStatus[id % 5]!!
+private fun genStatus(id: Int): Status = issueIdToStatus[id % 5]
 
 fun populate() {
     (0..5).forEach { productId ->
@@ -66,7 +65,7 @@ fun populate() {
                 Issues.insert {
                     it[description] = "Issue $issueId"
                     it[product] = prodId
-                    it[status] = genStatus(issueId)
+                    it[status] = genStatus(issueId).toString()
                     it[priority] = 1
                     it[creationDate] = CurrentDateTime
                     it[anticipatedRelease] = relId
@@ -142,7 +141,7 @@ class Issue(
     var creationDate by Issues.creationDate
     private var _status by Issues.status
     var status: Status
-        set(newStatus: Status) {
+        set(newStatus) {
             _status = newStatus.toString()
         }
         get() = requireNotNull(_status.toStatus())
@@ -151,11 +150,11 @@ class Issue(
 
 fun String.toStatus(): Status? =
     when (this) {
-        "CREATED" -> Status.Created
-        "ASSESSED" -> Status.Assessed
-        "IN_PROGRESS" -> Status.InProgress
-        "DONE" -> Status.Done
-        "CANCELLED" -> Status.Cancelled
+        "Created" -> Status.Created
+        "Assessed" -> Status.Assessed
+        "InProgress" -> Status.InProgress
+        "Done" -> Status.Done
+        "Cancelled" -> Status.Cancelled
         else -> null
     }
 

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -112,7 +112,7 @@ object Issues : IntIdTable() {
     val product = reference("product", Products)
     val anticipatedRelease = reference("release", Releases)
     val creationDate = datetime("creation_date")
-    val status = varchar("status", 9)
+    val status = varchar("status", 11)
     val priority = short("priority")
 }
 

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -14,6 +14,7 @@ a function which sets up the database.
 
 package anttracker.db
 
+import anttracker.issues.Status
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -139,9 +140,24 @@ class Issue(
     var product by ProductEntity referencedOn Issues.product
     var anticipatedRelease by Release referencedOn Issues.anticipatedRelease
     var creationDate by Issues.creationDate
-    var status by Issues.status
+    private var _status by Issues.status
+    var status: Status
+        set(newStatus: Status) {
+            _status = newStatus.toString()
+        }
+        get() = requireNotNull(_status.toStatus())
     var priority by Issues.priority
 }
+
+fun String.toStatus(): Status? =
+    when (this) {
+        "CREATED" -> Status.Created
+        "ASSESSED" -> Status.Assessed
+        "IN_PROGRESS" -> Status.InProgress
+        "DONE" -> Status.Done
+        "CANCELLED" -> Status.Cancelled
+        else -> null
+    }
 
 /** ---
  * Represents the priority an issue can have, being in [1, 5]

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -57,7 +57,7 @@ fun populate() {
             val relId =
                 Releases.insert {
                     it[product] = prodId
-                    it[releaseId] = "$id"
+                    it[releaseId] = "$prodId-$id"
                     it[releaseDate] = CurrentDateTime
                 } get Releases.id
             (0..20).forEach { issueId ->
@@ -113,6 +113,8 @@ class Release(
     var releaseId by Releases.releaseId
     var product by ProductEntity referencedOn Releases.product
     var releaseDate by Releases.releaseDate
+
+    override fun toString(): String = releaseId
 }
 
 /** ---

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -39,6 +39,17 @@ fun setupSchema(shouldPopulate: Boolean) {
     }
 }
 
+private val issueIdToStatus =
+    mapOf(
+        0 to "CREATED",
+        1 to "ASSESSED",
+        2 to "IN_PROGRESS",
+        3 to "DONE",
+        4 to "CANCELLED",
+    )
+
+private fun genStatus(id: Int): String = issueIdToStatus[id % 5]!!
+
 fun populate() {
     (0..5).forEach { productId ->
         val prodId = Products.insert { it[name] = "Product $productId" } get Products.id
@@ -54,7 +65,7 @@ fun populate() {
                 Issues.insert {
                     it[description] = "Issue $issueId"
                     it[product] = prodId
-                    it[status] = "done"
+                    it[status] = genStatus(issueId)
                     it[priority] = 1
                     it[creationDate] = CurrentDateTime
                     it[anticipatedRelease] = relId

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -144,6 +144,7 @@ class Issue(
     private var _status by Issues.status
     var status: Status
         set(newStatus) {
+            println(newStatus.toString())
             _status = newStatus.toString()
         }
         get() = requireNotNull(_status.toStatus())

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -47,6 +47,15 @@ data class IssueInformation(
     val priority: Priority,
 )
 
+private val statusToString: Map<Status, String> =
+    mapOf(
+        Status.Created to "CREATED",
+        Status.Assessed to "ASSESSED",
+        Status.InProgress to "IN_PROGRESS",
+        Status.Done to "DONE",
+        Status.Cancelled to "CANCELLED",
+    )
+
 sealed class Status {
     data object Created : Status()
 
@@ -57,6 +66,8 @@ sealed class Status {
     data object Done : Status()
 
     data object Cancelled : Status()
+
+    override fun toString(): String = statusToString[this]!!
 }
 
 /** ---

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -47,15 +47,6 @@ data class IssueInformation(
     val priority: Priority,
 )
 
-private val statusToString: Map<Status, String> =
-    mapOf(
-        Status.Created to "CREATED",
-        Status.Assessed to "ASSESSED",
-        Status.InProgress to "IN_PROGRESS",
-        Status.Done to "DONE",
-        Status.Cancelled to "CANCELLED",
-    )
-
 sealed class Status {
     data object Created : Status()
 
@@ -66,8 +57,6 @@ sealed class Status {
     data object Done : Status()
 
     data object Cancelled : Status()
-
-    override fun toString(): String = statusToString[this]!!
 }
 
 /** ---

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -47,6 +47,18 @@ data class IssueInformation(
     val priority: Priority,
 )
 
+sealed class Status {
+    data object Created : Status()
+
+    data object Assessed : Status()
+
+    data object InProgress : Status()
+
+    data object Done : Status()
+
+    data object Cancelled : Status()
+}
+
 /** ---
  * This data class represents the valid values an issue id can take on,
  * being between 1-99.

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -127,7 +127,7 @@ private fun editAnticipatedRelease(issue: Issue): Screen =
 /**
  * Represents how the date will be formatted.
  */
-private val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+private val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
 
 private fun editPriority(issue: Issue): Screen =
     screenWithMenu {

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -129,6 +129,24 @@ private fun editAnticipatedRelease(issue: Issue): Screen =
  */
 private val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
 
+private fun editPriority(issue: Issue): Screen =
+    screenWithMenu {
+        var newPriority = ""
+        content { t ->
+            newPriority = t.prompt("Please enter priority", (1..5).map(Int::toString))
+            printIssueSummary(t, issue)
+            t.title("Update: Priority")
+            t.printLine("OLD: ${issue.priority}")
+            t.printLine("NEW: $newPriority")
+        }
+        option("Save") {
+            updateIssueAndGoBackToMenu(issue) {
+                it.priority = newPriority.toShort()
+            }
+        }
+        option("Back") { viewIssueMenu(issue) }
+    }
+
 /** ----
  * This function shows all the information present within the passed issue
  * and prompts the user to edit either the description, priority, status,
@@ -141,7 +159,7 @@ private fun viewIssueMenu(
         title("Issue #${issue.id}")
         transaction {
             option("Description: ${issue.description}") { editDescription(issue) }
-            option("Priority: ${issue.priority}") { noIssuesMatching }
+            option("Priority: ${issue.priority}") { editPriority(issue) }
             option("Status: ${issue.status}") { noIssuesMatching }
             option("AntRel: ${issue.anticipatedRelease.releaseId}") { editAnticipatedRelease(issue) }
             option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -147,20 +147,11 @@ private fun editPriority(issue: Issue): Screen =
         option("Back") { viewIssueMenu(issue) }
     }
 
-val nextPossibleState: Map<Status, List<Status>> =
+val nextPossibleStates: Map<Status, List<Status>> =
     mapOf(
         Status.Created to listOf(Status.Assessed),
         Status.Assessed to listOf(Status.InProgress, Status.Done, Status.Cancelled),
         Status.InProgress to listOf(Status.Done, Status.Cancelled),
-    )
-
-private val statusToString: Map<Status, String> =
-    mapOf(
-        Status.Created to "CREATED",
-        Status.Assessed to "ASSESSED",
-        Status.InProgress to "IN_PROGRESS",
-        Status.Done to "DONE",
-        Status.Cancelled to "CANCELLED",
     )
 
 private val toStatus: Map<String, Status> =
@@ -182,23 +173,28 @@ private fun confirmNewStatus(
                 printIssueSummary(t, issue)
                 t.title("Update: Status")
                 t.printLine("OLD: ${issue.status}")
-                t.printLine("NEW: ${statusToString[newStatus]}")
+                t.printLine("NEW: $newStatus")
             }
         }
         option("Save") {
             updateIssueAndGoBackToMenu(issue) {
-                it.status = statusToString[newStatus]!!
+                it.status = "$newStatus"
             }
         }
         option("Back") { editStatus(issue) }
     }
 
-private fun editStatus(issue: Issue): Screen =
+private fun editStatus(
+    issue: Issue, // in
+): Screen =
     screenWithMenu {
-        nextPossibleState[toStatus[issue.status]]?.forEach { status ->
-            option(statusToString[status]!!) { confirmNewStatus(status, issue) }
+        toStatus[issue.status].let {
+            nextPossibleStates[it]?.forEach { status ->
+                option("$status") { confirmNewStatus(status, issue) }
+            }
         }
         option("Back") { viewIssueMenu(issue) }
+        promptMessage("Select the line of the new status for the issue.")
     }
 
 /** ----

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -129,23 +129,36 @@ private fun editAnticipatedRelease(issue: Issue): Screen =
  */
 private val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
 
-private fun editPriority(issue: Issue): Screen =
+private fun editIssueAttribute(
+    issue: Issue,
+    get: (Issue) -> String,
+    setter: (String, Issue) -> Unit,
+    attributeName: String,
+    choices: List<String>,
+): Screen =
     screenWithMenu {
-        var newPriority = ""
+        var newVal = ""
         content { t ->
-            newPriority = t.prompt("Please enter priority", (1..5).map(Int::toString))
+            newVal = t.prompt("Please enter $attributeName", choices)
             printIssueSummary(t, issue)
-            t.title("Update: Priority")
-            t.printLine("OLD: ${issue.priority}")
-            t.printLine("NEW: $newPriority")
+            t.title("Update: $attributeName")
+            t.printLine("OLD: ${get(issue)}")
+            t.printLine("NEW: $newVal")
         }
         option("Save") {
-            updateIssueAndGoBackToMenu(issue) {
-                it.priority = newPriority.toShort()
-            }
+            updateIssueAndGoBackToMenu(issue) { setter(newVal, it) }
         }
         option("Back") { viewIssueMenu(issue) }
     }
+
+private fun editPriority(issue: Issue): Screen =
+    editIssueAttribute(
+        issue,
+        { it.priority.toString() },
+        { newVal, target -> target.priority = newVal.toShort() },
+        "Priority",
+        (1..5).map(Int::toString),
+    )
 
 val nextPossibleStates: Map<Status, List<Status>> =
     mapOf(

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -29,31 +29,6 @@ private val noIssuesMatching =
         }
     }
 
-/** ----
- * This function displays a screen where the user is presented with the
- * option of saving their issue with an edited description or going back
- * to the previous menu.
------ */
-private fun editDescription(
-    issue: Issue, // in
-): Screen =
-    screenWithMenu {
-        var newDescription = ""
-        content { t ->
-            newDescription = t.prompt("Please enter description")
-            printIssueSummary(t, issue)
-            t.title("Update: Description")
-            t.printLine("OLD: ${issue.description}")
-            t.printLine("NEW: $newDescription")
-        }
-        option("Save") {
-            updateIssueAndGoBackToMenu(issue) {
-                it.description = newDescription
-            }
-        }
-        option("Back") { viewIssueMenu(issue) }
-    }
-
 /** ---
  * Updates the issue using the function passed and returns
  * to the view issues menu.
@@ -132,9 +107,9 @@ private val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
 private fun editIssueAttribute(
     issue: Issue,
     get: (Issue) -> String,
-    setter: (String, Issue) -> Unit,
     attributeName: String,
     choices: List<String>,
+    setter: (String, Issue) -> Unit,
 ): Screen =
     screenWithMenu {
         var newVal = ""
@@ -155,10 +130,19 @@ private fun editPriority(issue: Issue): Screen =
     editIssueAttribute(
         issue,
         { it.priority.toString() },
-        { newVal, target -> target.priority = newVal.toShort() },
         "Priority",
         (1..5).map(Int::toString),
-    )
+    ) { newVal, target -> target.priority = newVal.toShort() }
+
+/** ----
+ * This function displays a screen where the user is presented with the
+ * option of saving their issue with an edited description or going back
+ * to the previous menu.
+----- */
+private fun editDescription(issue: Issue) =
+    editIssueAttribute(issue, { it.description }, "Description", emptyList()) { newVal, target ->
+        target.description = newVal
+    }
 
 val nextPossibleStates: Map<Status, List<Status>> =
     mapOf(

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -10,12 +10,9 @@ submenus contained within the user will interact with.
 package anttracker.issues
 
 import anttracker.db.Issue
-import anttracker.db.Release
-import anttracker.db.Releases
 import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.format.DateTimeFormatter
-import kotlin.reflect.KMutableProperty1
 
 // -------
 
@@ -23,193 +20,17 @@ import kotlin.reflect.KMutableProperty1
  * This menu serves as a placeholder for other menus which have
  * not been fully fleshed out.
 --- */
-private val noIssuesMatching =
+internal val noIssuesMatching =
     screenWithMenu {
         content { t ->
             t.printLine("There are no issues matching the criteria")
         }
     }
 
-/** ---
- * Updates the issue using the function passed and returns
- * to the view issues menu.
---- */
-private fun updateIssueAndGoBackToMenu(
-    issue: Issue, // in
-    updateFn: (it: Issue) -> Unit, // in
-): Screen {
-    val updatedIssue = transaction { Issue.findByIdAndUpdate(issue.id.value, updateFn) }
-    require(updatedIssue != null)
-    return viewIssueMenu(updatedIssue)
-}
-
-/** ----
- * This function prints out all the information contained within an issue.
------ */
-private fun printIssueSummary(
-    t: Terminal, // in
-    issue: Issue, // in
-) {
-    transaction {
-        t.title("Summary")
-        t.printLine("Description: ${issue.description}")
-        t.printLine("Priority: ${issue.priority}")
-        t.printLine("Status: ${issue.status}")
-        t.printLine("AntRel: ${issue.anticipatedRelease.releaseId}")
-        t.printLine("Created: ${issue.creationDate.format(formatter)}")
-        t.printLine()
-    }
-}
-
-/** ----
- * This function presents a screen where the user is given a choice of saving their
- * issue with an updated anticipated release or going back to the previous menu.
------ */
-private fun confirmNewRelease(
-    newRelease: Release, // in
-    issue: Issue, // in
-): Screen =
-    screenWithMenu {
-        content { t ->
-            transaction {
-                printIssueSummary(t, issue)
-                t.title("Update: Release")
-                t.printLine("OLD: ${issue.anticipatedRelease.releaseId}")
-                t.printLine("NEW: ${newRelease.releaseId}")
-            }
-        }
-        option("Save") {
-            updateIssueAndGoBackToMenu(issue) {
-                it.anticipatedRelease = newRelease
-            }
-        }
-        option("Back") { editAnticipatedRelease(issue) }
-    }
-
-/** ----
- * This function shows the release versions the user can pick from
- * for the updated value of the anticipated release.
------ */
-private fun editAnticipatedRelease(issue: Issue): Screen =
-    screenWithMenu {
-        transaction {
-            Release
-                .find { Releases.product eq issue.product.id }
-                .forEach { option(it.releaseId) { confirmNewRelease(it, issue) } }
-        }
-        promptMessage("Select the line corresponding to the new release id you want.")
-    }
-
 /**
  * Represents how the date will be formatted.
  */
-private val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
-
-private fun <T> editIssueAttribute(
-    issue: Issue,
-    prop: KMutableProperty1<Issue, T>,
-    choices: List<String> = emptyList(),
-    parse: (String) -> T,
-): Screen =
-    screenWithMenu {
-        var newVal = ""
-        content { t ->
-            newVal = t.prompt("Please enter ${prop.name}", choices)
-            printIssueSummary(t, issue)
-            t.title("Update: ${prop.name}")
-            t.printLine("OLD: ${prop.get(issue)}")
-            t.printLine("NEW: $newVal")
-        }
-        option("Save") {
-            updateIssueAndGoBackToMenu(issue) { prop.set(it, parse(newVal)) }
-        }
-        option("Back") { viewIssueMenu(issue) }
-    }
-
-private fun editPriority(issue: Issue): Screen =
-    editIssueAttribute(
-        issue,
-        Issue::priority,
-        (1..5).map(Int::toString),
-    ) { newVal -> newVal.toShort() }
-
-/** ----
- * This function displays a screen where the user is presented with the
- * option of saving their issue with an edited description or going back
- * to the previous menu.
------ */
-private fun editDescription(issue: Issue) = editIssueAttribute(issue, Issue::description) { it }
-
-val nextPossibleStates: Map<Status, List<Status>> =
-    mapOf(
-        Status.Created to listOf(Status.Assessed),
-        Status.Assessed to listOf(Status.InProgress, Status.Done, Status.Cancelled),
-        Status.InProgress to listOf(Status.Done, Status.Cancelled),
-    )
-
-private val toStatus: Map<String, Status> =
-    mapOf(
-        "CREATED" to Status.Created,
-        "ASSESSED" to Status.Assessed,
-        "IN_PROGRESS" to Status.InProgress,
-        "DONE" to Status.Done,
-        "CANCELLED" to Status.Cancelled,
-    )
-
-private fun confirmNewStatus(
-    newStatus: Status, // in
-    issue: Issue, // in
-): Screen =
-    screenWithMenu {
-        content { t ->
-            transaction {
-                printIssueSummary(t, issue)
-                t.title("Update: Status")
-                t.printLine("OLD: ${issue.status}")
-                t.printLine("NEW: $newStatus")
-            }
-        }
-        option("Save") {
-            updateIssueAndGoBackToMenu(issue) {
-                it.status = "$newStatus"
-            }
-        }
-        option("Back") { editStatus(issue) }
-    }
-
-private fun editStatus(
-    issue: Issue, // in
-): Screen =
-    screenWithMenu {
-        toStatus[issue.status].let {
-            nextPossibleStates[it]?.forEach { status ->
-                option("$status") { confirmNewStatus(status, issue) }
-            }
-        }
-        option("Back") { viewIssueMenu(issue) }
-        promptMessage("Select the line of the new status for the issue.")
-    }
-
-/** ----
- * This function shows all the information present within the passed issue
- * and prompts the user to edit either the description, priority, status,
- * or anticipated release
------ */
-private fun viewIssueMenu(
-    issue: Issue, // in
-): Screen =
-    screenWithMenu {
-        title("Issue #${issue.id}")
-        transaction {
-            option("Description: ${issue.description}") { editDescription(issue) }
-            option("Priority: ${issue.priority}") { editPriority(issue) }
-            option("Status: ${issue.status}") { editStatus(issue) }
-            option("AntRel: ${issue.anticipatedRelease.releaseId}") { editAnticipatedRelease(issue) }
-            option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }
-            option("Print") { noIssuesMatching }
-        }
-        promptMessage("Enter 1, 2, 3, or 4 to edit the respective fields.")
-    }
+internal val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
 
 // This data type represents the mapping between a row
 // number and the issue corresponding to it

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -92,6 +92,9 @@ fun displayAllIssuesMenu(
                 selectIssueToViewMenu(it)
             }
         }
+        promptMessage(
+            "Enter 1 to select a filter, 2 to print, 3 to view the next page, and 4 to view an issue on the page.",
+        )
         val columns =
             listOf("ID" to 2, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
         content { t ->

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -156,11 +156,11 @@ val nextPossibleState: Map<Status, List<Status>> =
 
 private val statusToString: Map<Status, String> =
     mapOf(
-        Status.Created to "Created",
-        Status.Assessed to "Assessed",
-        Status.InProgress to "In Progress",
-        Status.Done to "Done",
-        Status.Cancelled to "Cancelled",
+        Status.Created to "CREATED",
+        Status.Assessed to "ASSESSED",
+        Status.InProgress to "IN_PROGRESS",
+        Status.Done to "DONE",
+        Status.Cancelled to "CANCELLED",
     )
 
 private val toStatus: Map<String, Status> =
@@ -173,9 +173,25 @@ private val toStatus: Map<String, Status> =
     )
 
 private fun confirmNewStatus(
-    newStatus: Status,
-    issue: Issue,
-): Screen = noIssuesMatching
+    newStatus: Status, // in
+    issue: Issue, // in
+): Screen =
+    screenWithMenu {
+        content { t ->
+            transaction {
+                printIssueSummary(t, issue)
+                t.title("Update: Status")
+                t.printLine("OLD: ${issue.status}")
+                t.printLine("NEW: ${statusToString[newStatus]}")
+            }
+        }
+        option("Save") {
+            updateIssueAndGoBackToMenu(issue) {
+                it.status = statusToString[newStatus]!!
+            }
+        }
+        option("Back") { editStatus(issue) }
+    }
 
 private fun editStatus(issue: Issue): Screen =
     screenWithMenu {
@@ -203,7 +219,7 @@ private fun viewIssueMenu(
             option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }
             option("Print") { noIssuesMatching }
         }
-        promptMessage("Enter 1, 2, or 3 to edit the respective fields.")
+        promptMessage("Enter 1, 2, 3, or 4 to edit the respective fields.")
     }
 
 // This data type represents the mapping between a row

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -147,6 +147,44 @@ private fun editPriority(issue: Issue): Screen =
         option("Back") { viewIssueMenu(issue) }
     }
 
+val nextPossibleState: Map<Status, List<Status>> =
+    mapOf(
+        Status.Created to listOf(Status.Assessed),
+        Status.Assessed to listOf(Status.InProgress, Status.Done, Status.Cancelled),
+        Status.InProgress to listOf(Status.Done, Status.Cancelled),
+    )
+
+private val statusToString: Map<Status, String> =
+    mapOf(
+        Status.Created to "Created",
+        Status.Assessed to "Assessed",
+        Status.InProgress to "In Progress",
+        Status.Done to "Done",
+        Status.Cancelled to "Cancelled",
+    )
+
+private val toStatus: Map<String, Status> =
+    mapOf(
+        "CREATED" to Status.Created,
+        "ASSESSED" to Status.Assessed,
+        "IN_PROGRESS" to Status.InProgress,
+        "DONE" to Status.Done,
+        "CANCELLED" to Status.Cancelled,
+    )
+
+private fun confirmNewStatus(
+    newStatus: Status,
+    issue: Issue,
+): Screen = noIssuesMatching
+
+private fun editStatus(issue: Issue): Screen =
+    screenWithMenu {
+        nextPossibleState[toStatus[issue.status]]?.forEach { status ->
+            option(statusToString[status]!!) { confirmNewStatus(status, issue) }
+        }
+        option("Back") { viewIssueMenu(issue) }
+    }
+
 /** ----
  * This function shows all the information present within the passed issue
  * and prompts the user to edit either the description, priority, status,
@@ -160,7 +198,7 @@ private fun viewIssueMenu(
         transaction {
             option("Description: ${issue.description}") { editDescription(issue) }
             option("Priority: ${issue.priority}") { editPriority(issue) }
-            option("Status: ${issue.status}") { noIssuesMatching }
+            option("Status: ${issue.status}") { editStatus(issue) }
             option("AntRel: ${issue.anticipatedRelease.releaseId}") { editAnticipatedRelease(issue) }
             option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }
             option("Print") { noIssuesMatching }

--- a/src/main/kotlin/anttracker/issues/Terminal.kt
+++ b/src/main/kotlin/anttracker/issues/Terminal.kt
@@ -11,7 +11,6 @@ the user, and displaying a table.
 
 package anttracker.issues
 
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -71,7 +70,7 @@ class Terminal {
     /**
      * Represents the wanted format for the date.
      */
-    private val formatter = DateTimeFormatter.ofPattern("yyyy/mm/dd")
+    private val formatter = DateTimeFormatter.ofPattern("YYYY-MM-dd")
 
     /** -----
      * This function displays a table to the screen using the passed columns and rows.
@@ -98,7 +97,6 @@ class Terminal {
                         when {
                             (col is Number) -> col.toString().padStart(length)
                             (col is LocalDateTime) -> col.format(formatter).padEnd(length)
-                            (col is LocalDate) -> col.format(formatter).padStart(length)
                             else -> col.toString().padEnd(length)
                         }
                     }.joinToString(separator = " | ", postfix = " |", prefix = " | ")

--- a/src/main/kotlin/anttracker/issues/Terminal.kt
+++ b/src/main/kotlin/anttracker/issues/Terminal.kt
@@ -34,27 +34,17 @@ class Terminal {
         println(text)
     }
 
-    /** ---
-     * prints the given message and returns what the user entered.
-     --- */
-    fun prompt(
-        message: String, // in
-    ): String {
-        println(message)
-        return readln()
-    }
-
     /** ----
      * This function prompts the user for input and only returns their
      * input if it is valid. Otherwise, it prompts the user again.
      ----- */
     fun prompt(
         message: String, // in
-        choices: List<String>, // in
+        choices: List<String> = emptyList(), // in
     ): String {
         println(message)
         val choice = readln()
-        if (choices.contains(choice)) {
+        if (choices.isEmpty() || choices.contains(choice)) {
             return choice
         }
         return prompt(message, choices)

--- a/src/main/kotlin/anttracker/issues/Terminal.kt
+++ b/src/main/kotlin/anttracker/issues/Terminal.kt
@@ -70,7 +70,7 @@ class Terminal {
     /**
      * Represents the wanted format for the date.
      */
-    private val formatter = DateTimeFormatter.ofPattern("YYYY-MM-dd")
+    private val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
 
     /** -----
      * This function displays a table to the screen using the passed columns and rows.

--- a/src/main/kotlin/anttracker/issues/ViewIssueMenu.kt
+++ b/src/main/kotlin/anttracker/issues/ViewIssueMenu.kt
@@ -1,0 +1,156 @@
+package anttracker.issues
+
+import anttracker.db.Issue
+import anttracker.db.Release
+import anttracker.db.Releases
+import anttracker.db.toStatus
+import org.jetbrains.exposed.sql.transactions.transaction
+import kotlin.reflect.KMutableProperty1
+
+/** ----
+ * Represents a map between a status and possible transitions.
+--- */
+private val nextPossibleStates: Map<Status, List<Status>> =
+    mapOf(
+        Status.Created to listOf(Status.Assessed),
+        Status.Assessed to listOf(Status.InProgress, Status.Done, Status.Cancelled),
+        Status.InProgress to listOf(Status.Done, Status.Cancelled),
+    )
+
+/** ---
+ * Edits the status of the issue using the possible transitions for the current status.
+--- */
+private fun editStatus(
+    issue: Issue, // in
+): Screen {
+    val nextStates = nextPossibleStates[issue.status] ?: return viewIssueMenu(issue)
+    val fn = editIssueAttribute(Issue::status, nextStates.map { it.toString() }) { requireNotNull(it.toStatus()) }
+    return fn(issue)
+}
+
+/** ----
+ * This function shows all the information present within the passed issue
+ * and prompts the user to edit either the description, priority, status,
+ * or anticipated release
+----- */
+internal fun viewIssueMenu(
+    issue: Issue, // in
+): Screen =
+    screenWithMenu {
+        title("Issue #${issue.id}")
+        transaction {
+            option("Description: ${issue.description}") { editDescription(issue) }
+            option("Priority: ${issue.priority}") { editPriority(issue) }
+            option("Status: ${issue.status}") { editStatus(issue) }
+            option("AntRel: ${issue.anticipatedRelease.releaseId}") { editAnticipatedRelease(issue) }
+            option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }
+            option("Print") { noIssuesMatching }
+        }
+        promptMessage("Enter 1, 2, 3, or 4 to edit the respective fields.")
+    }
+
+/** ----
+ * This function presents a screen where the user is given a choice of saving their
+ * issue with an updated anticipated release or going back to the previous menu.
+----- */
+private fun confirmNewRelease(
+    newRelease: Release, // in
+    issue: Issue, // in
+): Screen =
+    screenWithMenu {
+        content { t ->
+            transaction {
+                printIssueSummary(t, issue)
+                t.title("Update: Release")
+                t.printLine("OLD: ${issue.anticipatedRelease.releaseId}")
+                t.printLine("NEW: ${newRelease.releaseId}")
+            }
+        }
+        option("Save") {
+            updateIssueAndGoBackToMenu(issue) {
+                it.anticipatedRelease = newRelease
+            }
+        }
+        option("Back") { editAnticipatedRelease(issue) }
+    }
+
+/** ----
+ * This function shows the release versions the user can pick from
+ * for the updated value of the anticipated release.
+----- */
+private fun editAnticipatedRelease(issue: Issue): Screen =
+    screenWithMenu {
+        transaction {
+            Release
+                .find { Releases.product eq issue.product.id }
+                .forEach { option(it.releaseId) { confirmNewRelease(it, issue) } }
+        }
+        promptMessage("Select the line corresponding to the new release id you want.")
+    }
+
+/** ----
+ * This function prints out all the information contained within an issue.
+----- */
+private fun printIssueSummary(
+    t: Terminal, // in
+    issue: Issue, // in
+) {
+    transaction {
+        t.title("Summary")
+        t.printLine("Description: ${issue.description}")
+        t.printLine("Priority: ${issue.priority}")
+        t.printLine("Status: ${issue.status}")
+        t.printLine("AntRel: ${issue.anticipatedRelease.releaseId}")
+        t.printLine("Created: ${issue.creationDate.format(formatter)}")
+        t.printLine()
+    }
+}
+
+private fun <T> editIssueAttribute(
+    prop: KMutableProperty1<Issue, T>,
+    choices: List<String> = emptyList(),
+    parse: (String) -> T,
+): (Issue) -> Screen =
+    { issue: Issue ->
+        screenWithMenu {
+            var newVal = ""
+            content { t ->
+
+                newVal = t.prompt("Please enter ${prop.name}", choices)
+                printIssueSummary(t, issue)
+                t.title("Update: ${prop.name}")
+                t.printLine("OLD: ${prop.get(issue)}")
+                t.printLine("NEW: $newVal")
+            }
+            option("Save") {
+                updateIssueAndGoBackToMenu(issue) { prop.set(it, parse(newVal)) }
+            }
+            option("Back") { viewIssueMenu(issue) }
+        }
+    }
+
+/** ---
+ * Updates the issue using the function passed and returns
+ * to the view issues menu.
+--- */
+private fun updateIssueAndGoBackToMenu(
+    issue: Issue, // in
+    updateFn: (it: Issue) -> Unit, // in
+): Screen {
+    val updatedIssue = transaction { Issue.findByIdAndUpdate(issue.id.value, updateFn) }
+    require(updatedIssue != null)
+    return viewIssueMenu(updatedIssue)
+}
+
+private val editPriority =
+    editIssueAttribute(
+        Issue::priority,
+        (1..5).map(Int::toString),
+    ) { newVal -> newVal.toShort() }
+
+/** ----
+ * This function displays a screen where the user is presented with the
+ * option of saving their issue with an edited description or going back
+ * to the previous menu.
+----- */
+private val editDescription = editIssueAttribute(Issue::description) { it }

--- a/src/main/kotlin/anttracker/issues/ViewIssueMenu.kt
+++ b/src/main/kotlin/anttracker/issues/ViewIssueMenu.kt
@@ -41,13 +41,20 @@ internal fun viewIssueMenu(
         transaction {
             option("Description: ${issue.description}") { editDescription(issue) }
             option("Priority: ${issue.priority}") { editPriority(issue) }
-            option("Status: ${issue.status}") { editStatus(issue) }
+            option("Status: ${issue.status} ${canBeChanged(issue.status)}") { editStatus(issue) }
             option("AntRel: ${issue.anticipatedRelease.releaseId}") { editAnticipatedRelease(issue) }
             option("Created: ${issue.creationDate.format(formatter)} (not editable)") { viewIssueMenu(issue) }
             option("Print") { noIssuesMatching }
         }
         promptMessage("Enter 1, 2, 3, or 4 to edit the respective fields.")
     }
+
+/** ----
+ * Returns a string indicating whether the status can be changed.
+--- */
+private fun canBeChanged(
+    status: Status, // in
+): String = if (status == Status.Done || status == Status.Cancelled) "(not editable)" else ""
 
 /** ----
  * This function presents a screen where the user is given a choice of saving their
@@ -115,7 +122,7 @@ private fun <T> editIssueAttribute(
         screenWithMenu {
             var newVal = ""
             content { t ->
-
+                t.printLine("Options: ${choices.joinToString(", ")}")
                 newVal = t.prompt("Please enter ${prop.name}", choices)
                 printIssueSummary(t, issue)
                 t.title("Update: ${prop.name}")


### PR DESCRIPTION
## Summary

Added `editIssueAttribute` which creates a menu for editing the attribute passed.

Added the menus for editing the status and priority of an issue.

This is how it looks when editing the priority of an issue.


https://github.com/user-attachments/assets/f445c117-3a73-4e0d-9c87-9748042a36bb



This is how it looks when editing the status of an issue.

https://github.com/user-attachments/assets/72a70233-c32e-41f6-b4f3-39ebf8022dea



## Changes

### src/main/kotlin/anttracker/issues/Issue.kt
* Added the `Status` data type to represent the status an issue can have

### src/main/kotlin/anttracker/issues/ViewIssueMenu.kt
* Added `viewIssueMenu` and all the submenus within it
* Added `editPriority` as the menu for editing the priority of an issue
* Added `editStatus` as the menu for editing the status of an issue



