### PR TITLE
62 - requests for an issue fit on a single page

### DIFF
--- a/src/main/kotlin/anttracker/Contact.kt
+++ b/src/main/kotlin/anttracker/Contact.kt
@@ -11,7 +11,6 @@ package anttracker.contact
 
 import anttracker.db.*
 import org.jetbrains.exposed.dao.IntEntity
-
 import org.jetbrains.exposed.sql.transactions.transaction
 
 // ----------------------------------------------------------------------------
@@ -46,9 +45,7 @@ open class PageOf<T : IntEntity> {
         loadContents()
     }
 
-    fun lastPage(): Boolean {
-        return pagenum >= lastPageNum
-    }
+    fun lastPage(): Boolean = pagenum >= lastPageNum
 
     fun initLastPageNum(totalRecords: Int) {
         lastPageNum = Math.ceil(totalRecords.toDouble() / limit).toInt()
@@ -56,7 +53,7 @@ open class PageOf<T : IntEntity> {
 }
 
 // PageOfContact
-class PageOfContact : PageOf<ContactEntity>() {
+class PageOfContact : PageOf<Contact>() {
     fun display() {
         for ((index, contactRecord) in contents.withIndex()) {
             println("${index + 1}. ${contactRecord.name}")
@@ -66,9 +63,10 @@ class PageOfContact : PageOf<ContactEntity>() {
     override fun loadContents() {
         contents.clear()
         transaction {
-            val output = ContactEntity
-                .all()
-                .limit(limit, offset = (pagenum * limit).toLong())
+            val output =
+                Contact
+                    .all()
+                    .limit(limit, offset = (pagenum * limit).toLong())
             output.forEach {
                 contents.add(it)
             }
@@ -77,7 +75,7 @@ class PageOfContact : PageOf<ContactEntity>() {
 }
 
 // Display pages of contacts to console and select one
-fun selectContact(): ContactEntity? {
+fun selectContact(): Contact? {
     val contactPage = PageOfContact()
     contactPage.loadContents()
     contactPage.display()
@@ -93,6 +91,7 @@ fun selectContact(): ContactEntity? {
                     contactPage.display()
                 }
             }
+
             else -> {
                 linenum = userInput.toIntOrNull()
                 if (linenum == null || linenum !in 1..contactPage.contents.size) {
@@ -112,7 +111,7 @@ fun selectContact(): ContactEntity? {
 //     input when necessary, re-prompting where necessary.
 // Returns the created contact.
 // ---
-fun enterContactInformation(): ContactEntity? {
+fun enterContactInformation(): Contact? {
     while (true) {
         println("Please enter contact name (1-50 characters). ` to abort:")
         val name = readln()
@@ -150,14 +149,15 @@ fun enterContactInformation(): ContactEntity? {
             department = ""
         }
 
-        val contact = transaction {
-            ContactEntity.new {
-                this.name = name
-                this.phoneNumber = phone
-                this.email = email
-                this.department = department
+        val contact =
+            transaction {
+                Contact.new {
+                    this.name = name
+                    this.phoneNumber = phone
+                    this.email = email
+                    this.department = department
+                }
             }
-        }
 
         println("Contact ${contact.name} has been created.")
         return contact
@@ -167,8 +167,7 @@ fun enterContactInformation(): ContactEntity? {
 // ----------------------------------------------------------------------------
 // Returns all information about the contact identified by a given name.
 // ---
-fun getContactInfo(name: String): ContactEntity? {
-    return transaction {
-        ContactEntity.find { Contacts.name eq name }.firstOrNull()
+fun getContactInfo(name: String): Contact? =
+    transaction {
+        Contact.find { Contacts.name eq name }.firstOrNull()
     }
-}

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -33,7 +33,7 @@ fun displayRequester(request: Request?) {
     // get full information about this contact
     val contact =
         transaction {
-            Contact.find { Contacts.id eq request.contact }.firstOrNull()
+            Contact.find { Contacts.id eq request.contact.id }.firstOrNull()
         }
 
     if (contact == null) {
@@ -86,7 +86,7 @@ fun enterRequestInformation(): Request? {
             Request.new {
                 this.affectedRelease = release.id
                 this.issue = issue.id
-                this.contact = contact.id
+                this.contact = contact
                 this.requestDate = LocalDateTime.now()
             }
     }

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -31,9 +31,10 @@ fun displayRequester(request: Request?) {
     }
 
     // get full information about this contact
-    val contact = transaction {
-        ContactEntity.find { Contacts.id eq request.contact }.firstOrNull()
-    }
+    val contact =
+        transaction {
+            Contact.find { Contacts.id eq request.contact }.firstOrNull()
+        }
 
     if (contact == null) {
         println("Error: Bad contact for request")
@@ -81,12 +82,13 @@ fun enterRequestInformation(): Request? {
     var request: Request? = null
 
     transaction {
-        request = Request.new {
-            this.affectedRelease = release.id
-            this.issue = issue.id
-            this.contact = contact.id
-            this.requestDate = LocalDateTime.now()
-        }
+        request =
+            Request.new {
+                this.affectedRelease = release.id
+                this.issue = issue.id
+                this.contact = contact.id
+                this.requestDate = LocalDateTime.now()
+            }
     }
 
     println("Created request:")

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -61,14 +61,29 @@ fun populate() {
                     it[releaseDate] = CurrentDateTime
                 } get Releases.id
             (0..20).forEach { issueId ->
-
-                Issues.insert {
-                    it[description] = "Issue $issueId"
-                    it[product] = prodId
-                    it[status] = genStatus(issueId).toString()
-                    it[priority] = 1
-                    it[creationDate] = CurrentDateTime
-                    it[anticipatedRelease] = relId
+                val issId =
+                    Issues.insert {
+                        it[description] = "Issue $issueId"
+                        it[product] = prodId
+                        it[status] = "done"
+                        it[priority] = 1
+                        it[creationDate] = CurrentDateTime
+                        it[anticipatedRelease] = relId
+                    } get Issues.id
+                (0..45).forEach { requestId ->
+                    val contId =
+                        Contacts.insert {
+                            it[name] = "a-$requestId"
+                            it[email] = "a-$requestId@sfu.ca"
+                            it[phoneNumber] = "12345678901"
+                            it[department] = "Marketing"
+                        } get Contacts.id
+                    Requests.insert {
+                        it[affectedRelease] = relId
+                        it[issue] = issId
+                        it[requestDate] = CurrentDateTime
+                        it[contact] = contId
+                    }
                 }
             }
         }
@@ -186,10 +201,10 @@ object Contacts : IntIdTable() {
 /** ---
  * Represents a single row in the contacts table.
 --- */
-class ContactEntity(
+class Contact(
     id: EntityID<Int>,
 ) : IntEntity(id) {
-    companion object : IntEntityClass<ContactEntity>(Contacts)
+    companion object : IntEntityClass<Contact>(Contacts)
 
     var name by Contacts.name
     var email by Contacts.email
@@ -217,6 +232,6 @@ class Request(
 
     var affectedRelease by Requests.affectedRelease
     var issue by Requests.issue
-    var contact by Requests.contact
+    var contact by Contact referencedOn Requests.contact
     var requestDate by Requests.requestDate
 }

--- a/src/main/kotlin/anttracker/db/SetupSchema.kt
+++ b/src/main/kotlin/anttracker/db/SetupSchema.kt
@@ -65,7 +65,7 @@ fun populate() {
                     Issues.insert {
                         it[description] = "Issue $issueId"
                         it[product] = prodId
-                        it[status] = "done"
+                        it[status] = genStatus(issueId).toString()
                         it[priority] = 1
                         it[creationDate] = CurrentDateTime
                         it[anticipatedRelease] = relId

--- a/src/main/kotlin/anttracker/issues/Issue.kt
+++ b/src/main/kotlin/anttracker/issues/Issue.kt
@@ -127,6 +127,8 @@ data class PageOf<T>(
     val limit: Int = 20,
 )
 
+fun <T> PageOf<T>.next() = this.copy(offset = this.offset + this.limit)
+
 /** ---
  * This class represents a page of issues that
  * includes a filter

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -9,7 +9,7 @@ submenus contained within the user will interact with.
 
 package anttracker.issues
 
-import anttracker.db.Issue
+import anttracker.db.*
 import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.format.DateTimeFormatter
@@ -30,7 +30,44 @@ internal val noIssuesMatching =
 /**
  * Represents how the date will be formatted.
  */
-internal val formatter = DateTimeFormatter.ofPattern("YYYY/MM/dd")
+internal val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+
+private fun requestToRow(
+    request: Request, // in
+): List<Any> =
+    listOf(
+        request.affectedRelease,
+        request.requestDate,
+        request.contact.name,
+        request.contact.email,
+        request.contact.department,
+    )
+
+private fun viewRequests(
+    issue: Issue,
+    page: PageOf<Request> = PageOf(),
+): Screen =
+    screenWithTable {
+        table {
+            columns(
+                "Affected Release" to 17,
+                "Date requested" to 14,
+                "Name" to 32,
+                "Email" to 24,
+                "Department" to 12,
+            )
+            query {
+                Request
+                    .find { Requests.issue eq issue.id }
+                    .limit(page.limit, page.offset)
+                    .map(::requestToRow)
+            }
+
+            emptyMessage("No requests found.")
+            nextPage { viewRequests(issue, page.next()) }
+        }
+        promptMessage("Press 1 to go to the next page. 2 to print.")
+    }
 
 // This data type represents the mapping between a row
 // number and the issue corresponding to it
@@ -75,43 +112,33 @@ private fun selectIssueToViewMenu(
 fun displayAllIssuesMenu(
     page: PageWithFilter, // in
 ): Screen =
-    screenWithMenu {
+    screenWithTable {
         title("Search Results")
         option("Select filter") { mkIssuesMenu(page) }
-        option("Print") { screenWithMenu { content { t -> t.printLine("Not currently implemented. In next version") } } }
-        option("Next page") { displayAllIssuesMenu(page.next()) }
-        option("View issue") {
-            transaction {
-                Issue
-                    .all()
-                    .with(Issue::anticipatedRelease)
-                    .limit(page.pageInfo.limit, page.pageInfo.offset)
-                    .zip(1..20) { issue, index -> index to issue }
-                    .toMap()
-            }.let {
-                selectIssueToViewMenu(it)
-            }
-        }
-        promptMessage(
-            "Enter 1 to select a filter, 2 to print, 3 to view the next page, and 4 to view an issue on the page.",
-        )
-        val columns =
-            listOf("ID" to 2, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
-        content { t ->
-            transaction {
+        option("View issue") { displayViewIssuesMenu(page) }
+        table {
+            columns("ID" to 2, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
+            query {
                 Issue
                     .all()
                     .limit(page.pageInfo.limit, page.pageInfo.offset)
                     .map(::toRow)
-                    .let {
-                        if (it.isEmpty()) {
-                            t.printLine("No more issues")
-                        } else {
-                            t.displayTable(columns, it)
-                        }
-                    }
             }
+            emptyMessage("No issues found.")
+            nextPage { displayAllIssuesMenu(page.next()) }
         }
+    }
+
+private fun displayViewIssuesMenu(page: PageWithFilter) =
+    transaction {
+        Issue
+            .all()
+            .with(Issue::anticipatedRelease)
+            .limit(page.pageInfo.limit, page.pageInfo.offset)
+            .zip(1..20) { issue, index -> index to issue }
+            .toMap()
+    }.let {
+        selectIssueToViewMenu(it)
     }
 
 /** ------

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -32,43 +32,6 @@ internal val noIssuesMatching =
  */
 internal val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
 
-private fun requestToRow(
-    request: Request, // in
-): List<Any> =
-    listOf(
-        request.affectedRelease,
-        request.requestDate,
-        request.contact.name,
-        request.contact.email,
-        request.contact.department,
-    )
-
-private fun viewRequests(
-    issue: Issue,
-    page: PageOf<Request> = PageOf(),
-): Screen =
-    screenWithTable {
-        table {
-            columns(
-                "Affected Release" to 17,
-                "Date requested" to 14,
-                "Name" to 32,
-                "Email" to 24,
-                "Department" to 12,
-            )
-            query {
-                Request
-                    .find { Requests.issue eq issue.id }
-                    .limit(page.limit, page.offset)
-                    .map(::requestToRow)
-            }
-
-            emptyMessage("No requests found.")
-            nextPage { viewRequests(issue, page.next()) }
-        }
-        promptMessage("Press 1 to go to the next page. 2 to print.")
-    }
-
 // This data type represents the mapping between a row
 // number and the issue corresponding to it
 typealias RowToIssuePage = Map<Int, Issue>

--- a/src/main/kotlin/anttracker/issues/Issues.kt
+++ b/src/main/kotlin/anttracker/issues/Issues.kt
@@ -80,7 +80,7 @@ fun displayAllIssuesMenu(
         option("Select filter") { mkIssuesMenu(page) }
         option("View issue") { displayViewIssuesMenu(page) }
         table {
-            columns("ID" to 2, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
+            columns("ID" to 7, "Description" to 30, "Priority" to 9, "Status" to 14, "AntRel" to 8, "Created" to 10)
             query {
                 Issue
                     .all()

--- a/src/main/kotlin/anttracker/issues/ScreenWithTable.kt
+++ b/src/main/kotlin/anttracker/issues/ScreenWithTable.kt
@@ -1,0 +1,68 @@
+package anttracker.issues
+
+import anttracker.db.Request
+import org.jetbrains.exposed.sql.transactions.transaction
+
+private fun requestToRow(
+    request: Request, // in
+): List<Any> =
+    listOf(
+        request.affectedRelease,
+        request.requestDate,
+        request.contact.name,
+        request.contact.email,
+        request.contact.department,
+    )
+
+class ScreenWithTable : ScreenWithMenu() {
+    private var table: TableConfiguration = TableConfiguration()
+
+    fun table(config: TableConfiguration.() -> Unit) {
+        this.table = TableConfiguration()
+        config(table)
+        option("Next page") { table.nextPage!!.run { this() } }
+        option("Print") { screenWithMenu { content { t -> t.printLine("Not currently implemented. In next version") } } }
+        content { t ->
+            transaction {
+                table.fetchRows().let { rows ->
+                    if (rows.isEmpty()) {
+                        t.printLine(table.emptyMessage)
+                    } else {
+                        t.displayTable(table.columns, rows)
+                    }
+                }
+            }
+        }
+    }
+}
+
+class TableConfiguration {
+    var fetchRows: () -> List<List<Any>> = { emptyList() }
+    var columns: List<Pair<String, Int>> = emptyList()
+    var emptyMessage: String = ""
+    var nextPage: ScreenHandler? = null
+
+    fun query(query: () -> List<List<Any>>/* in */) {
+        this.fetchRows = query
+    }
+
+    fun columns(vararg columns: Pair<String, Int>/* in */) {
+        this.columns = columns.toList()
+    }
+
+    fun emptyMessage(message: String/* in */) {
+        this.emptyMessage = message
+    }
+
+    fun nextPage(nextPage: ScreenHandler/* in */) {
+        this.nextPage = nextPage
+    }
+}
+
+fun screenWithTable(
+    config: ScreenWithTable.() -> Unit, // in
+): Screen {
+    val menu = ScreenWithTable()
+    config(menu)
+    return menu
+}

--- a/src/test/kotlin/anttracker/ContactTest.kt
+++ b/src/test/kotlin/anttracker/ContactTest.kt
@@ -30,9 +30,10 @@ class ContactTest :
                     val contactCreated = enterContactInformation() ?: throw Exception()
 
                     // find the contact stored in the database identified by the created contact
-                    val contactFound = transaction {
-                        ContactEntity.find {Contacts.id eq contactCreated.id}.firstOrNull()
-                    }
+                    val contactFound =
+                        transaction {
+                            Contact.find { Contacts.id eq contactCreated.id }.firstOrNull()
+                        }
 
                     contactCreated shouldBe contactFound
                 }
@@ -41,15 +42,16 @@ class ContactTest :
                 it("should be findable in the database") {
                     // delete all contacts currently stored in the database
                     transaction {
-                        ContactEntity.all().forEach { it.delete() }
+                        Contact.all().forEach { it.delete() }
                     }
 
                     // prompts user input to create contacts
-                    val contactsCreated = listOf(
-                        enterContactInformation(),
-                        enterContactInformation(),
-                        enterContactInformation()
-                    )
+                    val contactsCreated =
+                        listOf(
+                            enterContactInformation(),
+                            enterContactInformation(),
+                            enterContactInformation(),
+                        )
 
                     // all created contacts should not be null
                     contactsCreated[0] shouldNotBe null
@@ -57,9 +59,10 @@ class ContactTest :
                     contactsCreated[2] shouldNotBe null
 
                     // find the contact stored in the database identified by the created contact
-                    val contactsFound = transaction {
-                        ContactEntity.all()
-                    }
+                    val contactsFound =
+                        transaction {
+                            Contact.all()
+                        }
 
                     contactsFound.shouldContainOnly(contactsCreated)
                 }


### PR DESCRIPTION
## Summary

Added `viewRequests` which generates a menu for viewing the requests associated with an issue.

Added `screenWithTable` type to model a screen showing a table with pagination.

This is how it looks when viewing the requests for a specific issue.

https://github.com/user-attachments/assets/8f25f767-0fc3-40c3-b6fe-38760fcb804b



## Changes

### src/main/kotlin/anttracker/issues/ScreenWithTable.kt
* Added the `ScreenWithTable` class

### src/main/kotlin/anttracker/issues/Issues.kt
* Added `viewRequests` as the menu for the requests pertaining to an issue

### src/main/kotlin/anttracker/db/SetupSchema.kt
* Fixed definition for `Request`


