### PR TITLE
Let new issues have a null anticipated release

### DIFF
--- a/src/main/kotlin/anttracker/Contact.kt
+++ b/src/main/kotlin/anttracker/Contact.kt
@@ -138,14 +138,20 @@ private class PageOfContact : PageOf<Contact>(Contact) {
 }
 
 // Display pages of contacts to console and select one
-fun selectContact(): Contact? {
+fun selectContact(
+    nullAction: String? = null // in
+): Contact? {
     val contactPage = PageOfContact()
     contactPage.loadRecords() // Adjust limit and offset as necessary
     contactPage.display()
 
     var linenum: Int? = null
     while (linenum == null) {
-        println("Please select contact. ` to abort:")
+        if (nullAction == null) {
+            println("Please select contact. ` to abort:")
+        } else {
+            println("Please select contact. ` to $nullAction:")
+        }
         val userInput = readln()
         when (userInput) {
             "`" -> return null

--- a/src/main/kotlin/anttracker/Release.kt
+++ b/src/main/kotlin/anttracker/Release.kt
@@ -43,6 +43,7 @@ fun menu() {
 // ---
 fun selectRelease(
     productName: String, // in
+    nullAction: String? = null // in
 ): Release? {
     val relPage = PageOfReleases(productName)
     relPage.loadRecords()
@@ -52,7 +53,11 @@ fun selectRelease(
 
     // Prompt user until system receives valid line number.
     while (linenum == null) {
-        println(promptSelectRel) // i.e. "Please select release. ` to abort:"
+        if (nullAction == null) {
+            println(promptSelectRel) // i.e. "Please select release. ` to abort:"
+        } else {
+            print("\nPlease select release. ` to $nullAction: ")
+        }
         val userInput = readln()
         when (userInput) {
             "`" -> return null // User wants to abort

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -183,7 +183,7 @@ private fun enterIssueInformation(
     // select description of issue; loops until a valid desc is entered
     while (desc == null) {
         // prompt user for input
-        println("Issue description (max 30 chars). ` to abort:")
+        print("Issue description (max 30 chars). ` to abort: ")
 
         when (val inputDesc = readln()) {
             // user aborts
@@ -203,6 +203,7 @@ private fun enterIssueInformation(
     }
 
     // select release or leave blank (null)
+    println("${product.name} Releases:")
     val release = selectRelease(product.name, "leave blank")
 
     var priority: Short? = null
@@ -303,6 +304,7 @@ private fun displayRequester(
 // Returns the created request.
 fun enterRequestInformation(): Request? {
     // select product for this request
+    println("Products:")
     val product = selectProduct() ?: return null
 
     // select release for this request
@@ -310,6 +312,7 @@ fun enterRequestInformation(): Request? {
     val release = selectRelease(product.name) ?: return null
 
     // select contact for this request
+    println("Contacts:")
     var contact = selectContact("create contact")
 
     // if user doesn't select a contact, make them enter the contact information
@@ -318,6 +321,7 @@ fun enterRequestInformation(): Request? {
     }
 
     // select issue for this request
+    println("Issues:")
     var issue = selectIssue(product.name)
 
     // check if user aborted the select issue menu: offer to create an issue instead

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -130,7 +130,7 @@ private fun selectIssue(
 
         // prompt user for input
         println() // blank line
-        print("Please select issue. ` to create a new issue: ")
+        print("Please select issue. ` to create issue: ")
 
         // switch on user selection
         when (val selection = readln()) {
@@ -306,7 +306,7 @@ fun enterRequestInformation(): Request? {
     val product = selectProduct() ?: return null
 
     // select release for this request
-    println("Product ${product.name} Releases:")
+    println("${product.name} Releases:")
     val release = selectRelease(product.name) ?: return null
 
     // select contact for this request

--- a/src/main/kotlin/anttracker/Request.kt
+++ b/src/main/kotlin/anttracker/Request.kt
@@ -130,7 +130,7 @@ private fun selectIssue(
 
         // prompt user for input
         println() // blank line
-        print("Please select issue. ` to create an issue instead: ")
+        print("Please select issue. ` to create a new issue: ")
 
         // switch on user selection
         when (val selection = readln()) {
@@ -202,8 +202,8 @@ private fun enterIssueInformation(
         }
     }
 
-    // select anticipated release for this issue
-    val release = selectRelease(product.name) ?: return null
+    // select release or leave blank (null)
+    val release = selectRelease(product.name, "leave blank")
 
     var priority: Short? = null
 
@@ -270,7 +270,9 @@ private fun displayRequestColumnTitles() {
 // ----------------------------------------------------------------
 
 // display a given request to the screen
-private fun displayRequester(request: Request) {
+private fun displayRequester(
+    request: Request // in
+) {
     // strings to be printed (with fixed lengths)
     var affrel = ""
     var name = ""
@@ -304,10 +306,11 @@ fun enterRequestInformation(): Request? {
     val product = selectProduct() ?: return null
 
     // select release for this request
+    println("Product ${product.name} Releases:")
     val release = selectRelease(product.name) ?: return null
 
     // select contact for this request
-    var contact = selectContact()
+    var contact = selectContact("create contact")
 
     // if user doesn't select a contact, make them enter the contact information
     if (contact == null) {


### PR DESCRIPTION
# Summary

This PR lets a user create an issue through the new request menu without an anticipated release (null value).

It also updates some of the outputs to be a little prettier.